### PR TITLE
feat: 상품 등록 시 이미지 저장

### DIFF
--- a/src/main/java/com/example/place/domain/Image/entity/Image.java
+++ b/src/main/java/com/example/place/domain/Image/entity/Image.java
@@ -25,13 +25,21 @@ public class Image {
 	@JoinColumn(name = "item_id")
 	private Item item;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "newsfeed_id")
-	private NewsFeed newsFeed;
+	// @ManyToOne(fetch = FetchType.LAZY)
+	// @JoinColumn(name = "newsfeed_id")
+	// private NewsFeed newsFeed;
 
 	private String imageUrl;
 
 	private Boolean isMain = false;
 
+	private Image(Item item, String imageUrl, Boolean isMain) {
+		this.item = item;
+		this.imageUrl = imageUrl;
+		this.isMain = isMain;
+	}
 
+	public static Image of(Item item, String imageUrl, Boolean isMain) {
+		return new Image(item, imageUrl, isMain);
+	}
 }

--- a/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.example.place.domain.Image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.place.domain.Image.entity.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/example/place/domain/Image/service/ImageService.java
+++ b/src/main/java/com/example/place/domain/Image/service/ImageService.java
@@ -1,0 +1,23 @@
+package com.example.place.domain.Image.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.place.domain.Image.entity.Image;
+import com.example.place.domain.Image.repository.ImageRepository;
+import com.example.place.domain.item.entity.Item;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+	private final ImageRepository imageRepository;
+
+	@Transactional
+	public void saveImage(Item item, String imageUrl, Boolean isMain) {
+		Image image = Image.of(item, imageUrl, isMain);
+		imageRepository.save(image);
+	}
+}

--- a/src/main/java/com/example/place/domain/item/controller/ItemController.java
+++ b/src/main/java/com/example/place/domain/item/controller/ItemController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -29,7 +30,7 @@ public class ItemController {
      */
     @PostMapping
     public ResponseEntity<ApiResponseDto<ItemResponse>> createItem(
-            @RequestBody ItemRequest request,
+        @Valid @RequestBody ItemRequest request,
             @AuthenticationPrincipal CustomPrincipal principal
     ) {
         ItemResponse item = itemService.createItem(principal.getId(), request);

--- a/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
+++ b/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
@@ -25,6 +25,8 @@ public class ItemRequest {
     private Long count;
     private LocalDateTime salesStartAt;
     private LocalDateTime salesEndAt;
+    private List<String> images;
+    private int mainIndex;
     private List<String> itemTagNames;
 
 

--- a/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
+++ b/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
@@ -1,6 +1,7 @@
 package com.example.place.domain.item.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
@@ -25,7 +26,9 @@ public class ItemRequest {
     private Long count;
     private LocalDateTime salesStartAt;
     private LocalDateTime salesEndAt;
+    @NotEmpty(message = "최소 1개의 이미지가 있어야합니다.")
     private List<String> images;
+    @NotNull(message = "대표 이미지 번호를 입력해주세요")
     private int mainIndex;
     private List<String> itemTagNames;
 

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -1,5 +1,6 @@
 package com.example.place.domain.item.service;
 
+import com.example.place.domain.Image.service.ImageService;
 import com.example.place.domain.item.dto.request.ItemRequest;
 import com.example.place.domain.item.dto.response.ItemResponse;
 import com.example.place.domain.item.entity.Item;
@@ -33,6 +34,7 @@ public class ItemService {
     private final ItemTagRepository itemTagRepository;
     private final TagRepository tagRepository;
     private final UserRepository userRepository;
+	private final ImageService imageService;
 
 
 	// 재고 감소
@@ -76,6 +78,13 @@ public class ItemService {
 				);
         itemRepository.save(item);
 
+		// 이미지 저장 로직
+		for (int i = 0; i < request.getImages().size(); i++) {
+			boolean isMain = (request.getMainIndex() == i);
+			imageService.saveImage(item, request.getImages().get(i), isMain);
+		}
+
+		//	태그 저장 로직
         for (String tagName: request.getItemTagNames()) {
             Tag tag = tagRepository.findByTagName(tagName)
                     .orElseGet(() -> tagRepository.save(new Tag(tagName)));

--- a/src/main/java/com/example/place/domain/newsfeed/entity/NewsFeed.java
+++ b/src/main/java/com/example/place/domain/newsfeed/entity/NewsFeed.java
@@ -24,7 +24,7 @@ public class NewsFeed {
 	private String title;
 	private String content;
 
-	@OneToMany(mappedBy = "newsFeed")
-	private List<Image> images = new ArrayList<>();
+	// @OneToMany(mappedBy = "newsFeed")
+	// private List<Image> images = new ArrayList<>();
 
 }


### PR DESCRIPTION
## 개요
상품 등록 시 리스트로 받은 이미지를 이미지 테이블에 저장합니다.
이때, 이미지는 대상 상품, 이미지 url, 대표 이미지 여부의 정보를 갖고 있습니다.

## 작업 사항
- 이미지 저장 서비스 로직
- 상품 등록 요청 시 이미지 필수 사항으로 추가
- 상품 등록시 이미지 저장 로직

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.
- 이미지 테이블과 새소식의 연관 관계를 끊었습니다.

## 기타 사항
- 관련 이슈: #28 
- 참고 자료: [링크]

---
