### PR TITLE
feat: 상품 삭제 시 이미지 삭제

### DIFF
--- a/src/main/java/com/example/place/domain/Image/entity/Image.java
+++ b/src/main/java/com/example/place/domain/Image/entity/Image.java
@@ -11,9 +11,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "images")
 public class Image {

--- a/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
@@ -1,8 +1,11 @@
 package com.example.place.domain.Image.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.place.domain.Image.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+	List<Image> findByItemId(Long itemId);
 }

--- a/src/main/java/com/example/place/domain/Image/service/ImageService.java
+++ b/src/main/java/com/example/place/domain/Image/service/ImageService.java
@@ -1,5 +1,7 @@
 package com.example.place.domain.Image.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.example.place.domain.Image.entity.Image;
@@ -15,9 +17,17 @@ public class ImageService {
 
 	private final ImageRepository imageRepository;
 
+	// 이미지 저장
 	@Transactional
 	public void saveImage(Item item, String imageUrl, Boolean isMain) {
 		Image image = Image.of(item, imageUrl, isMain);
 		imageRepository.save(image);
+	}
+
+	// 특정 itemId와 연관된 이미지를 일괄로 삭제
+	@Transactional
+	public void deleteImageByItemId(Long itemId) {
+		List<Image> images = imageRepository.findByItemId(itemId);
+		imageRepository.deleteAll(images);
 	}
 }

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -119,6 +119,10 @@ public class ItemService {
 		if(!findByIdOrElseThrow(itemId).getUser().getId().equals(userId)) {
 			throw new CustomException(ExceptionCode.FORBIDDEN_ITEM_DELETE);
 		}
+
+		// 연관 이미지 삭제
+		imageService.deleteImageByItemId(itemId);
+
 		itemRepository.deleteById(itemId);
 	}
 


### PR DESCRIPTION
## 개요
상품 삭제 시, 연관된 여러 개의 이미지를 이미지 테이블에 자동으로 삭제합니다.

## 작업 사항
- 이미지 삭제 서비스 로직 개발
- 상품 삭제 이미지 삭제 되도록 추가

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 현재 상품 삭제 시 태그 연관 관계에 문제가 있는 것으로 추정됩니다. 
   태그가 없는 상품은 상품과 연관 이미지 모두 정상 삭제 되는 것을 확인했습니다. 이점 참고 바랍니다.

## 기타 사항
- 관련 이슈: #58 
- 참고 자료: [링크]

---
