### PR TITLE
Issue/59 feature login tests

### DIFF
--- a/src/main/java/com/example/place/domain/user/entity/User.java
+++ b/src/main/java/com/example/place/domain/user/entity/User.java
@@ -47,4 +47,8 @@ public class User extends SoftDeleteEntity {
 		this.imageUrl = imageUrl != null ? imageUrl : DEFAULT_IMAGE_URL;
 		this.role = role;
 	}
+
+	public static User of(String name,String nickname,String email,String password , String imageUrl,UserRole role){
+		return new User(name,nickname,email,password,imageUrl,role);
+	}
 }

--- a/src/test/java/com/example/place/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/place/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,89 @@
+package com.example.place.domain.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.example.place.domain.auth.controller.dto.LoginRequestDto;
+import com.example.place.domain.auth.controller.dto.LoginResponseDto;
+import com.example.place.domain.auth.service.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("Controller:Auth")
+class AuthControllerTest {
+
+	private static final String ENDPOINT = "/api/login";
+	private static final String TEST_EMAIL = "test@example.com";
+	private static final String TEST_PASSWORD = "password123";
+	private static final String TEST_ACCESS_TOKEN = "test.access.token";
+	@MockitoBean
+	private AuthService authService;
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Test
+	@DisplayName("[200:OK] 로그인 성공 API")
+	void loginApi_Success() throws Exception {
+		// given
+		LoginRequestDto loginRequest = createLoginRequest(TEST_EMAIL, TEST_PASSWORD);
+		LoginResponseDto loginResponse = new LoginResponseDto(TEST_ACCESS_TOKEN);
+
+		when(authService.login(any(LoginRequestDto.class))).thenReturn(loginResponse);
+
+		// when
+		ResultActions resultActions = performPostLogin(loginRequest);
+
+		// then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(header().exists(AUTHORIZATION))
+			.andExpect(header().string(AUTHORIZATION, TEST_ACCESS_TOKEN))
+			.andExpect(jsonPath("message").value("로그인에 성공했습니다."))
+			.andExpect(jsonPath("data.accessToken").value(TEST_ACCESS_TOKEN))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("[400:BAD_REQUEST] 로그인 실패 - 입력값이 잘못됨")
+	void loginApi_Fails() throws Exception {
+		// given
+		LoginRequestDto emptyInputRequest = createLoginRequest("", "");
+
+		// when
+		ResultActions result = performPostLogin(emptyInputRequest);
+
+		// then
+		result
+			.andExpect(status().isBadRequest())
+			.andDo(print());
+	}
+
+	private LoginRequestDto createLoginRequest(String email, String password) {
+		return new LoginRequestDto(email, password);
+	}
+
+	private ResultActions performPostLogin(Object requestBody) throws Exception {
+		return mockMvc.perform(post(ENDPOINT)
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(requestBody))
+		);
+	}
+}

--- a/src/test/java/com/example/place/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/place/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,106 @@
+package com.example.place.domain.auth.service;
+
+import com.example.place.common.exception.enums.ExceptionCode;
+import com.example.place.common.exception.exceptionclass.CustomException;
+import com.example.place.common.security.jwt.JwtUtil;
+import com.example.place.domain.auth.controller.dto.LoginRequestDto;
+import com.example.place.domain.auth.controller.dto.LoginResponseDto;
+import com.example.place.domain.user.entity.User;
+import com.example.place.domain.user.entity.UserRole;
+import com.example.place.domain.user.repository.UserRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Service:Auth")
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	private static final String TEST_EMAIL = "test@example.com";
+	private static final String TEST_RAW_PASSWORD = "RAW_Test1234!";
+	private static final String TEST_ENCODED_PASSWORD = "ENCODED_Test1234!";
+	private static final String TEST_ACCESS_TOKEN = "test.access.token";
+	private static final User TEST_USER = User.of(
+		"testUser",
+		"testNickname",
+		TEST_EMAIL, TEST_ENCODED_PASSWORD,
+		null,
+		UserRole.USER
+	);
+
+	private static final LoginRequestDto TEST_LOGIN_REQUEST = new LoginRequestDto(TEST_EMAIL, TEST_RAW_PASSWORD);
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private JwtUtil jwtUtil;
+
+	@InjectMocks
+	private AuthService authService;
+
+	@Test
+	@DisplayName("로그인 성공")
+	void loginSuccess() {
+
+		// given
+		when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(TEST_USER));
+		when(passwordEncoder.matches(TEST_RAW_PASSWORD, TEST_ENCODED_PASSWORD)).thenReturn(true);
+		when(jwtUtil.createAccessToken(any())).thenReturn(TEST_ACCESS_TOKEN);
+
+		// when
+		LoginResponseDto response = authService.login(TEST_LOGIN_REQUEST);
+
+		// then
+		assertThat(response.getAccessToken()).isEqualTo(TEST_ACCESS_TOKEN);
+		verify(userRepository, times(1)).findByEmail(TEST_EMAIL);
+		verify(passwordEncoder, times(1)).matches(TEST_RAW_PASSWORD, TEST_ENCODED_PASSWORD);
+		verify(jwtUtil, times(1)).createAccessToken(any());
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 존재하지 않는 이메일")
+	void loginFail_userNotFound() {
+		// given
+		when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.empty());
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class, () -> authService.login(TEST_LOGIN_REQUEST));
+
+		assertThat(exception.getExceptionCode()).isEqualTo(ExceptionCode.INVALID_EMAIL_OR_PASSWORD);
+		verify(userRepository, times(1)).findByEmail(TEST_EMAIL);
+		verify(passwordEncoder, never()).matches(anyString(), anyString());
+		verify(jwtUtil, never()).createAccessToken(any(Long.class));
+	}
+
+	@Test
+	@DisplayName("로그인 실패 - 비밀번호 불일치")
+	void loginFail_passwordMismatch() {
+		// given
+		when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(TEST_USER));
+		when(passwordEncoder.matches(TEST_RAW_PASSWORD, TEST_ENCODED_PASSWORD)).thenReturn(false);
+
+		// when & then
+		CustomException exception = assertThrows(CustomException.class, () -> authService.login(TEST_LOGIN_REQUEST));
+
+		assertThat(exception.getExceptionCode()).isEqualTo(ExceptionCode.PASSWORD_MISMATCH);
+		verify(userRepository, times(1)).findByEmail(TEST_EMAIL);
+		verify(passwordEncoder, times(1)).matches(TEST_RAW_PASSWORD, TEST_ENCODED_PASSWORD);
+		verify(jwtUtil, never()).createAccessToken(any());
+	}
+}


### PR DESCRIPTION
작업 사항
 AuthController 로그인 API 단위 테스트 작성

 로그인 성공 시 Authorization 헤더 포함 응답 검증

 입력값 누락 시 400 BAD_REQUEST 응답 검증

 AuthService 단위 테스트 작성

 존재하지 않는 이메일 로그인 시 예외 발생 테스트

 비밀번호 불일치 시 예외 발생 테스트

 로그인 성공 시 access token 반환 검증

 테스트 중복 코드 제거를 위한 헬퍼 메서드 도입

 요청 생성 메서드

 MockMvc 로그인 요청 메서드

리뷰 요청 포인트
컨트롤러와 서비스 테스트 구조가 명확하게 분리되어 있는지 확인 부탁드립니다.

실패 케이스에 대한 예외 메시지 및 상태 코드가 적절한지 봐주세요.

테스트 네이밍과 시나리오 설명이 충분한지 확인해주세요.

기타 사항
관련 이슈: #59

참고 자료:

