### PR TITLE
feat: 상품 수정 시 이미지 수정

### DIFF
--- a/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
@@ -18,7 +18,7 @@ public enum ExceptionCode {
 	CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "내용을 입력해주세요."),
 	ADDRESS_REQUIRED(HttpStatus.BAD_REQUEST, "주소지가 입력되지 않았습니다."),
 	NOT_SALE_PERIOD(HttpStatus.BAD_REQUEST, "판매 기간이 아닙니다."),
-
+	INVALID_IMAGE_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "이미지 수정을 위해서는 이미지 URL 목록과 대표 이미지 인덱스를 함께 보내주세요"),
 
 	// 401 Unauthorized
 	LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),

--- a/src/main/java/com/example/place/domain/Image/entity/Image.java
+++ b/src/main/java/com/example/place/domain/Image/entity/Image.java
@@ -5,7 +5,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import com.example.place.domain.item.entity.Item;
-import com.example.place.domain.newsfeed.entity.NewsFeed;
 
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;

--- a/src/main/java/com/example/place/domain/Image/entity/Image.java
+++ b/src/main/java/com/example/place/domain/Image/entity/Image.java
@@ -34,7 +34,7 @@ public class Image {
 
 	private String imageUrl;
 
-	private Boolean isMain = false;
+	private boolean isMain = false;
 
 	private Image(Item item, String imageUrl, Boolean isMain) {
 		this.item = item;
@@ -44,5 +44,9 @@ public class Image {
 
 	public static Image of(Item item, String imageUrl, Boolean isMain) {
 		return new Image(item, imageUrl, isMain);
+	}
+
+	public void updateIsMain(boolean isMain) {
+		this.isMain = isMain;
 	}
 }

--- a/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
@@ -8,6 +8,4 @@ import com.example.place.domain.Image.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findByItemId(Long itemId);
-
-	void deleteByItemIdAndImageUrl(Long itemId, String imageUrl);
 }

--- a/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
@@ -8,4 +8,6 @@ import com.example.place.domain.Image.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findByItemId(Long itemId);
+
+	void deleteByItemIdAndImageUrl(Long itemId, String imageUrl);
 }

--- a/src/main/java/com/example/place/domain/Image/service/ImageService.java
+++ b/src/main/java/com/example/place/domain/Image/service/ImageService.java
@@ -51,8 +51,10 @@ public class ImageService {
 		toDelete.removeAll(newImageSet);
 
 		// 삭제 처리
-		for (String imageUrl : toDelete) {
-			imageRepository.deleteByItemIdAndImageUrl(item.getId(), imageUrl);
+		for (Image image : existingImages) {
+			if (toDelete.contains(image.getImageUrl())) {
+				imageRepository.delete(image);
+			}
 		}
 
 		// 새롭게 저장할 이미지 판별 	(new - existing)

--- a/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
+++ b/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
@@ -28,8 +28,7 @@ public class ItemRequest {
     private LocalDateTime salesEndAt;
     @NotEmpty(message = "최소 1개의 이미지가 있어야합니다.")
     private List<String> images;
-    @NotNull(message = "대표 이미지 번호를 입력해주세요")
-    private int mainIndex;
+    private Integer mainIndex;
     private List<String> itemTagNames;
 
 

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -109,7 +109,14 @@ public class ItemService {
 		item.updateItem(request);
 
 		// 연관 이미지 수정
-		imageService.updateImages(item, request.getImages(), request.getMainIndex());
+		if ((request.getImages() == null && request.getMainIndex() != null)
+			|| (request.getImages() != null && request.getMainIndex() == null)) {
+			throw new CustomException(ExceptionCode.INVALID_IMAGE_UPDATE_REQUEST);
+		}
+
+		if (request.getImages() != null && request.getMainIndex() != null) {
+			imageService.updateImages(item, request.getImages(), request.getMainIndex());
+		}
 
 		return ItemResponse.from(item);
 	}

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -79,13 +79,8 @@ public class ItemService {
 				);
         itemRepository.save(item);
 
-		// 이미지 저장 로직
-		int mainIndex = (request.getMainIndex() == null
-			|| request.getMainIndex() < 0
-			|| request.getMainIndex() >= request.getImages().size())
-			? 0 : request.getMainIndex();
-
-		imageService.saveImages(item, request.getImages(), mainIndex);
+		// 연관 이미지 저장
+		imageService.saveImages(item, request.getImages(), request.getMainIndex());
 
 		//	태그 저장 로직
         for (String tagName: request.getItemTagNames()) {


### PR DESCRIPTION
## 개요
상품 수정 시 연관 이미지도 함께 수정되게합니다.
이때, 이미지 목록은 최종적으로 저장될 이미지 목록을 전달합니다.
(기존의 이미지 중 계속 남겨두고 싶은 이미지가 있다면 목록에 함께 보내야합니다.)

이미지 관련 로직을 ImageService로 분리하는 방식으로 리팩토링도 진행했습니다.

## 작업 사항
- 이미지를 수정하는 기능 (새로운 이미지 추가 저장, 필요없어진 이미지 삭제, 대표이미지 재설정)
- 대표이미지 인덱스를 아무값이나 받을 수 있도록 범위를 넓혔습니다.
   null, 음수, 이미지 목록보다 큰 값이 오면 자동으로 0번 이미지가 대표이미지로 설정됩니다.
- 이미지 로직을 모두 ImageService로 이동

## 리뷰 요청 포인트
로직 흐름 자연스러운지 확인 부탁드립니다.
유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #66 
- 참고 자료: [링크]

---
