### PR TITLE
Issue/75 feature create logoutapi

### DIFF
--- a/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
@@ -51,7 +51,8 @@ public enum ExceptionCode {
 	OUT_OF_STOCK(HttpStatus.CONFLICT, "상품의 개수가 부족합니다."),
 	ALREADY_VOTED(HttpStatus.CONFLICT, "이미 투표한 게시글입니다."),
 	EXISTS_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-	EXISTS_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다.");
+	EXISTS_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
+	BLACKLISTED_TOKEN(HttpStatus.CONFLICT, "다시 로그인 해주세요.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/place/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/place/domain/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,5 +29,14 @@ public class AuthController {
 		LoginResponseDto loginResponse = authService.login(requestDto);
 		response.addHeader(HttpHeaders.AUTHORIZATION, loginResponse.getAccessToken());
 		return ResponseEntity.ok(new ApiResponseDto<>("로그인에 성공했습니다.", loginResponse));
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponseDto<String>> logout(
+		@RequestHeader(value = "Authorization", required = false) String bearerToken) {
+
+		authService.logout(bearerToken);
+
+		return ResponseEntity.ok(new ApiResponseDto<>("로그아웃 성공",null));
 	}
 }

--- a/src/main/java/com/example/place/domain/auth/domain/model/JwtBlacklistToken.java
+++ b/src/main/java/com/example/place/domain/auth/domain/model/JwtBlacklistToken.java
@@ -23,7 +23,7 @@ public class JwtBlacklistToken {
 	@Column(nullable = false)
 	private LocalDateTime blacklistedAt;
 
-	public JwtBlacklistToken(String token, LocalDateTime blacklistedAt) {
+	private JwtBlacklistToken(String token, LocalDateTime blacklistedAt) {
 		this.token = token;
 		this.blacklistedAt = blacklistedAt;
 	}

--- a/src/main/java/com/example/place/domain/auth/domain/model/JwtBlacklistToken.java
+++ b/src/main/java/com/example/place/domain/auth/domain/model/JwtBlacklistToken.java
@@ -1,0 +1,34 @@
+package com.example.place.domain.auth.domain.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "jwt_blacklist")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JwtBlacklistToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true, length = 500)
+	private String token;
+
+	@Column(nullable = false)
+	private LocalDateTime blacklistedAt;
+
+	public JwtBlacklistToken(String token, LocalDateTime blacklistedAt) {
+		this.token = token;
+		this.blacklistedAt = blacklistedAt;
+	}
+
+	public static JwtBlacklistToken of(String token) {
+		return new JwtBlacklistToken(token, LocalDateTime.now());
+	}
+}

--- a/src/main/java/com/example/place/domain/auth/domain/repository/JwtBlacklistRepository.java
+++ b/src/main/java/com/example/place/domain/auth/domain/repository/JwtBlacklistRepository.java
@@ -1,0 +1,9 @@
+package com.example.place.domain.auth.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.place.domain.auth.domain.model.JwtBlacklistToken;
+
+public interface JwtBlacklistRepository extends JpaRepository<JwtBlacklistToken,Long> {
+	boolean existsByToken(String token);
+}

--- a/src/main/java/com/example/place/domain/auth/service/JwtBlacklistService.java
+++ b/src/main/java/com/example/place/domain/auth/service/JwtBlacklistService.java
@@ -1,0 +1,24 @@
+package com.example.place.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.place.domain.auth.domain.model.JwtBlacklistToken;
+import com.example.place.domain.auth.domain.repository.JwtBlacklistRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class JwtBlacklistService {
+
+	private final JwtBlacklistRepository jwtBlacklistRepository;
+
+	public void addBlacklist(String token) {
+		JwtBlacklistToken blacklistToken = JwtBlacklistToken.of(token);
+		jwtBlacklistRepository.save(blacklistToken);
+	}
+
+	public boolean isBlacklisted(String token) {
+		return jwtBlacklistRepository.existsByToken(token);
+	}
+}


### PR DESCRIPTION
개요
로그아웃 기능 및 JWT 블랙리스트 검증 기능을 구현하여,
 로그아웃 시 토큰을 블랙리스트에 추가하고, 
블랙리스트에 포함된 토큰에 대한 요청을 409 상태코드로 처리하도록 수정했습니다.

작업 사항
로그아웃 시 JWT 토큰을 블랙리스트에 저장하는 기능 구현

JwtFilter에 블랙리스트 토큰 검증 로직 추가

블랙리스트 토큰 요청 시 409 Conflict 상태코드 및 적절한 에러 메시지 반환 처리

JwtUtil, JwtBlacklistService 연동 및 리팩토링

리뷰 요청 포인트
JwtFilter 내 블랙리스트 검증 로직의 위치와 흐름이 적절한지

예외 처리 및 응답 메시지 반환이 일관성 있고 명확한지

로그아웃 기능에서 블랙리스트 추가 과정이 올바르게 동작하는지

기타 사항
관련 이슈: #75 

참고 자료: 
---

