### PR TITLE
Issue/79 feature implement refresh token mechanism

### DIFF
--- a/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
@@ -27,6 +27,8 @@ public enum ExceptionCode {
 	INVALID_OR_MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰 정보입니다."),
 	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 만료됐습니다."),
+	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"리프레시 토큰이 유효하지 않습니다."),
+	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
 	INVALID_EMAIL_OR_PASSWORD(HttpStatus.UNAUTHORIZED, "잘못된 이메일 또는 비밀번호입니다."),
 
 	// 403 Forbidden

--- a/src/main/java/com/example/place/common/filter/JwtFilter.java
+++ b/src/main/java/com/example/place/common/filter/JwtFilter.java
@@ -52,7 +52,8 @@ public class JwtFilter extends OncePerRequestFilter implements Ordered {
 		String jwt = jwtUtil.subStringToken(bearerJwt);
 
 		if (!jwtUtil.validateToken(jwt)) {
-			throw new CustomException(ExceptionCode.INVALID_OR_MISSING_TOKEN);
+			filterChain.doFilter(request, response);
+			return;
 		}
 
 		String subject = jwtUtil.extractUserId(jwt);

--- a/src/main/java/com/example/place/common/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/place/common/security/jwt/JwtUtil.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtUtil {
 	private static final String BEARER_PREFIX = "Bearer ";
 	private static final Long TOKEN_TIME = 10 * 60 * 1000L;
+	private static final Long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L;
 
 	@Value("${SECRET_KEY}")
 	private String secretKey;
@@ -73,5 +74,17 @@ public class JwtUtil {
 
 	public String extractUserId(String token) {
 		return extractClaims(token).getSubject();
+	}
+	//리프레시 토큰 관련 로직
+
+	public String createRefreshToken(Long userId) {
+		Date date = new Date();
+
+		return Jwts.builder()
+				.setSubject(String.valueOf(userId))
+				.setExpiration(new Date(date.getTime() + REFRESH_TOKEN_TIME))
+				.setIssuedAt(date)
+				.signWith(key, signatureAlgorithm)
+				.compact();
 	}
 }

--- a/src/main/java/com/example/place/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/place/domain/auth/controller/AuthController.java
@@ -36,7 +36,7 @@ public class AuthController {
 
 		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken())
 			.httpOnly(true)
-			.secure(false)
+			.secure(true)
 			.path("/")
 			.maxAge(7 * 24 * 60 * 60)
 			.sameSite("Strict")

--- a/src/main/java/com/example/place/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/place/domain/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package com.example.place.domain.auth.controller;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -9,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.place.common.dto.ApiResponseDto;
+import com.example.place.common.exception.enums.ExceptionCode;
+import com.example.place.common.exception.exceptionclass.CustomException;
 import com.example.place.domain.auth.controller.dto.LoginRequestDto;
 import com.example.place.domain.auth.controller.dto.LoginResponseDto;
 import com.example.place.domain.auth.service.AuthService;
@@ -26,17 +30,54 @@ public class AuthController {
 	@PostMapping("/login")
 	public ResponseEntity<ApiResponseDto<LoginResponseDto>> loginApi(@Valid @RequestBody LoginRequestDto requestDto,
 		HttpServletResponse response) {
+
 		LoginResponseDto loginResponse = authService.login(requestDto);
 		response.addHeader(HttpHeaders.AUTHORIZATION, loginResponse.getAccessToken());
+
+		ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", loginResponse.getRefreshToken())
+			.httpOnly(true)
+			.secure(false)
+			.path("/")
+			.maxAge(7 * 24 * 60 * 60)
+			.sameSite("Strict")
+			.build();
+
+		response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 		return ResponseEntity.ok(new ApiResponseDto<>("로그인에 성공했습니다.", loginResponse));
 	}
 
 	@PostMapping("/logout")
 	public ResponseEntity<ApiResponseDto<String>> logout(
-		@RequestHeader(value = "Authorization", required = false) String bearerToken) {
+		@RequestHeader(value = "Authorization", required = false) String bearerToken,
+		@CookieValue(value = "refreshToken", required = false) String refreshToken,
+		HttpServletResponse response) {
 
-		authService.logout(bearerToken);
+		authService.logout(bearerToken, refreshToken);
 
-		return ResponseEntity.ok(new ApiResponseDto<>("로그아웃 성공",null));
+		ResponseCookie deleteRefreshTokenCookie = ResponseCookie.from("refreshToken", "")
+			.path("/")
+			.maxAge(0)
+			.httpOnly(true)
+			.secure(true)
+			.build();
+		response.addHeader(HttpHeaders.SET_COOKIE, deleteRefreshTokenCookie.toString());
+
+		return ResponseEntity.ok(new ApiResponseDto<>("로그아웃 성공", null));
+	}
+
+	@PostMapping("/refresh")
+	public ResponseEntity<ApiResponseDto<LoginResponseDto>> refreshAccessToken(
+		@CookieValue(name = "refreshToken", required = false) String refreshToken,
+		HttpServletResponse response) {
+
+		if (refreshToken == null) {
+			throw new CustomException(ExceptionCode.INVALID_REFRESH_TOKEN);
+		}
+
+		LoginResponseDto newTokens = authService.refreshAccessToken(refreshToken);
+
+		response.setHeader(HttpHeaders.AUTHORIZATION, newTokens.getAccessToken());
+
+		return ResponseEntity.ok(new ApiResponseDto<>("토큰 재발급 성공", newTokens));
 	}
 }

--- a/src/main/java/com/example/place/domain/auth/controller/dto/LoginResponseDto.java
+++ b/src/main/java/com/example/place/domain/auth/controller/dto/LoginResponseDto.java
@@ -5,8 +5,10 @@ import lombok.Getter;
 @Getter
 public class LoginResponseDto {
 	private final String accessToken;
+	private final String refreshToken;
 
-	public LoginResponseDto(String accessToken) {
+	public LoginResponseDto(String accessToken,String refreshToken) {
 		this.accessToken = accessToken;
+		this.refreshToken = refreshToken;
 	}
 }

--- a/src/main/java/com/example/place/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/place/domain/auth/service/AuthService.java
@@ -11,19 +11,20 @@ import com.example.place.domain.auth.controller.dto.LoginRequestDto;
 import com.example.place.domain.auth.controller.dto.LoginResponseDto;
 import com.example.place.domain.user.entity.User;
 import com.example.place.domain.user.repository.UserRepository;
+import com.example.place.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-	private final UserRepository userRepository;
+	private final UserService userService;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtBlacklistService jwtBlacklistService;
 	private final JwtUtil jwtUtil;
 
 	public LoginResponseDto login(LoginRequestDto requestDto) {
-		User user = userRepository.findByEmail(requestDto.getEmail())
+		User user = (User)userService.findByEmail(requestDto.getEmail())
 			.orElseThrow(() -> new CustomException(ExceptionCode.INVALID_EMAIL_OR_PASSWORD));
 
 		if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
@@ -33,7 +34,7 @@ public class AuthService {
 		String accessToken = jwtUtil.createAccessToken(user.getId());
 		String refreshToken = jwtUtil.createRefreshToken(user.getId());
 
-		return new LoginResponseDto(accessToken,refreshToken);
+		return new LoginResponseDto(accessToken, refreshToken);
 	}
 
 	@Transactional
@@ -59,10 +60,10 @@ public class AuthService {
 		}
 
 		String userIdStr = jwtUtil.extractUserId(refreshToken);
+
 		Long userId = Long.parseLong(userIdStr);
 
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_USER));
+		User user = userService.findUserById(userId);
 
 		String newAccessToken = jwtUtil.createAccessToken(user.getId());
 

--- a/src/main/java/com/example/place/domain/user/service/UserService.java
+++ b/src/main/java/com/example/place/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.example.place.domain.user.service;
 
+import java.util.Optional;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,8 @@ import com.example.place.domain.user.entity.User;
 import com.example.place.domain.user.entity.UserRole;
 import com.example.place.domain.user.repository.UserRepository;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -142,5 +146,10 @@ public class UserService {
 	public User findUserById(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_USER));
+	}
+
+	public Optional<Object> findByEmail(String email) {
+		return Optional.ofNullable(userRepository.findByEmail(email)
+			.orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_USER)));
 	}
 }


### PR DESCRIPTION
개요
리프레시 토큰을 이용해 액세스 토큰을 재발급하는 기능을 추가하고, 로그아웃 시 리프레시 토큰을 무효화하는 로직을 구현했습니다.

작업 사항
 refreshAccessToken 비즈니스 로직 추가

 /api/refresh 엔드포인트 구현 (액세스 토큰 재발급용)

 로그아웃 시 리프레시 토큰 무효화 처리 추가

 관련 테스트 코드 작성

## 리뷰 요청 포인트


## 기타 사항
-Jwt  필터 오류사항 발견 수정 추가

---
