### PR TITLE
feat: 상품 댓글 삭제 + refactor: 주석 추가 + 팩토리메서드 명명규칙에 따라 이름 변경 + 변수 이름 통일

### DIFF
--- a/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
@@ -43,6 +43,7 @@ public enum ExceptionCode {
 	FORBIDDEN_ORDER_ACCESS(HttpStatus.FORBIDDEN, "해당 주문은 본인의 주문이 아닙니다."),
 	ORDER_CANCEL_ACCESS_DENIED(HttpStatus.FORBIDDEN, "주문을 취소할 권한이 없습니다."),
 	FORBIDDEN_COMMENT_ACCESS(HttpStatus.FORBIDDEN, "본인 외에 댓글은 수정할 수 없습니다."),
+	FORBIDDEN_COMMENT_DELETE(HttpStatus.FORBIDDEN, "본인 외에 댓글은 삭제할 수 없습니다."),
 	DELETED_USER(HttpStatus.FORBIDDEN, "탈퇴한 사용자 입니다."),
 
 

--- a/src/main/java/com/example/place/domain/item/entity/Item.java
+++ b/src/main/java/com/example/place/domain/item/entity/Item.java
@@ -9,6 +9,7 @@ import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.item.dto.request.ItemRequest;
+import com.example.place.domain.itemcomment.entity.ItemComment;
 import com.example.place.domain.itemtag.entity.ItemTag;
 import com.example.place.domain.user.entity.User;
 
@@ -45,6 +46,9 @@ public class Item extends BaseEntity {
 
 	@OneToMany(mappedBy = "item", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
 	private List<ItemTag> itemTags = new ArrayList<>();
+
+	@OneToMany(mappedBy = "item", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	private List<ItemComment> comments = new ArrayList<>();
 
 	// 재고 감소
 	public void decreaseStock(Long quantity){

--- a/src/main/java/com/example/place/domain/itemcomment/controller/ItemCommentController.java
+++ b/src/main/java/com/example/place/domain/itemcomment/controller/ItemCommentController.java
@@ -6,6 +6,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -86,4 +87,22 @@ public class ItemCommentController {
 		return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseDto<>("댓글을 수정하였습니다.", response));
 	}
 
+	/**
+	 * 상품 댓글 삭제
+	 *
+	 * @param itemId
+	 * @param itemCommentId
+	 * @param principal
+	 * @return
+	 */
+	@DeleteMapping("/{itemCommentId}")
+	public ResponseEntity<ApiResponseDto> deleteItemComment(
+		@PathVariable Long itemId,
+		@PathVariable Long itemCommentId,
+		@AuthenticationPrincipal CustomPrincipal principal) {
+
+		itemCommentService.deleteItemComment(itemId, itemCommentId, principal);
+
+		return ResponseEntity.status(HttpStatus.OK).body(new ApiResponseDto<>("댓글을 삭제하였습니다.", null));
+	}
 }

--- a/src/main/java/com/example/place/domain/itemcomment/dto/response/ItemCommentResponse.java
+++ b/src/main/java/com/example/place/domain/itemcomment/dto/response/ItemCommentResponse.java
@@ -20,7 +20,7 @@ public class ItemCommentResponse {
 		this.createAt = createAt;
 	}
 
-	public static ItemCommentResponse of(ItemComment itemComment) {
+	public static ItemCommentResponse from(ItemComment itemComment) {
 		return new ItemCommentResponse(
 			itemComment.getUser().getNickname(),
 			itemComment.getUser().getImageUrl(),

--- a/src/main/java/com/example/place/domain/itemcomment/service/ItemCommentService.java
+++ b/src/main/java/com/example/place/domain/itemcomment/service/ItemCommentService.java
@@ -18,7 +18,6 @@ import com.example.place.domain.user.service.UserService;
 
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -29,6 +28,7 @@ public class ItemCommentService {
 	private final ItemService itemService;
 	private final UserService userService;
 
+	// 상품 댓글 저장
 	@Transactional
 	public ItemCommentResponse saveItemComment(Long itemId, ItemCommentRequest request,
 		CustomPrincipal principal) {
@@ -39,22 +39,24 @@ public class ItemCommentService {
 		Item item = itemService.findByIdOrElseThrow(itemId);
 
 		// 댓글 저장
-		ItemComment itemComment = ItemComment.of(user, item, request.getContent());
-		ItemComment saveItemComment = itemCommentRepository.save(itemComment);
+		ItemComment comment = ItemComment.of(user, item, request.getContent());
+		ItemComment saveComment = itemCommentRepository.save(comment);
 
 		// 응답 DTO로 반환
-		return ItemCommentResponse.of(saveItemComment);
+		return ItemCommentResponse.from(saveComment);
 	}
 
+	// 상품 댓글 조회
 	@Transactional(readOnly = true)
 	public Page<ItemCommentResponse> readItemComment(Long itemId, Pageable pageable) {
 		// 댓글 조회
 		Page<ItemComment> comments = itemCommentRepository.findByItemId(itemId, pageable);
 
 		// 응답 DTO로 반환
-		return comments.map(ItemCommentResponse::of);
+		return comments.map(ItemCommentResponse::from);
 	}
 
+	// 상품 댓글 수정
 	@Transactional
 	public ItemCommentResponse updateItemComment(Long itemId, Long itemCommentId, ItemCommentRequest request,
 		CustomPrincipal principal) {
@@ -75,9 +77,10 @@ public class ItemCommentService {
 		// 댓글 수정
 		comment.updateItemComment(request.getContent());
 
-		return ItemCommentResponse.of(comment);
+		return ItemCommentResponse.from(comment);
 	}
 
+	// 상품 댓글 삭제
 	@Transactional
 	public void deleteItemComment(Long itemId, Long itemCommentId, CustomPrincipal principal) {
 		// 삭제할 댓글 조회
@@ -97,5 +100,4 @@ public class ItemCommentService {
 		// 댓글 삭제
 		itemCommentRepository.deleteById(itemCommentId);
 	}
-
 }

--- a/src/main/java/com/example/place/domain/itemcomment/service/ItemCommentService.java
+++ b/src/main/java/com/example/place/domain/itemcomment/service/ItemCommentService.java
@@ -77,4 +77,25 @@ public class ItemCommentService {
 
 		return ItemCommentResponse.of(comment);
 	}
+
+	@Transactional
+	public void deleteItemComment(Long itemId, Long itemCommentId, CustomPrincipal principal) {
+		// 삭제할 댓글 조회
+		ItemComment comment = itemCommentRepository.findById(itemCommentId).
+			orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_COMMENT));
+
+		// 유효한 경로인지 확인(해당 itemCommentId의 대상 itemId가 일치하는지 확인)
+		if (comment.getItem().getId() != itemId) {
+			throw new CustomException(ExceptionCode.INVALID_PATH);
+		}
+
+		// 본인이 쓴 댓글인지 확인
+		if (comment.getUser().getId() != principal.getId()) {
+			throw new CustomException(ExceptionCode.FORBIDDEN_COMMENT_DELETE);
+		}
+
+		// 댓글 삭제
+		itemCommentRepository.deleteById(itemCommentId);
+	}
+
 }


### PR DESCRIPTION
## 개요
상품 댓글을 삭제합니다.

## 작업 사항
- 상품 댓글 삭제 기능
- 상품 삭제시 연관 댓글도 모두 삭제되도록 casecade설정
- 전체적으로 메서드 이름 주석 추가
- 팩토리 메서드 명명 규칙에 따라 이름 변경
- 변수 이름 통일

## 리뷰 요청 포인트
로직 흐름 자연스러운지 확인 부탁드립니다.
누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #69 
- 참고 자료: [링크]

---
