### PR TITLE
feat: 상품 응답값에 이미지 url 목록과 대표이미지를 포함하도록 추가

### DIFF
--- a/src/main/java/com/example/place/domain/Image/service/ImageService.java
+++ b/src/main/java/com/example/place/domain/Image/service/ImageService.java
@@ -30,7 +30,10 @@ public class ImageService {
 		for (int i = 0; i < imageUrls.size(); i++) {
 			boolean isMain = (validatedMainIndex == i);
 			Image image = Image.of(item, imageUrls.get(i), isMain);
+
 			imageRepository.save(image);
+
+			item.addImage(image); // 연관관계 양방향 설정
 		}
 	}
 

--- a/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
+++ b/src/main/java/com/example/place/domain/item/dto/request/ItemRequest.java
@@ -26,7 +26,7 @@ public class ItemRequest {
     private LocalDateTime salesStartAt;
     private LocalDateTime salesEndAt;
     @NotEmpty(message = "최소 1개의 이미지가 있어야합니다.")
-    private List<String> images;
+    private List<String> imageUrls;
     private Integer mainIndex;
     private List<String> itemTagNames;
 

--- a/src/main/java/com/example/place/domain/item/dto/response/ItemResponse.java
+++ b/src/main/java/com/example/place/domain/item/dto/response/ItemResponse.java
@@ -1,10 +1,12 @@
 package com.example.place.domain.item.dto.response;
 
+import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.item.entity.Item;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -16,9 +18,21 @@ public class ItemResponse {
     private Long count;
     private LocalDateTime salesStartAt;
     private LocalDateTime salesEndAt;
+    private List<String> imageUrls;
+    private int mainIndex;
     private List<String> tags;
 
     public static ItemResponse from(Item item) {
+        List<Image> images = item.getImages();
+        List<String> imageUrls = new ArrayList<>();
+        int mainIndex = 0;
+        for (int i = 0; i < images.size(); i++) {
+            imageUrls.add(images.get(i).getImageUrl());
+            if (images.get(i).isMain()) {
+                mainIndex = i;
+            }
+        }
+
         List<String> tagNames = item.getItemTags().stream()
                 .map(itemTag -> itemTag.getTag().getTagName())
                 .toList();
@@ -30,6 +44,8 @@ public class ItemResponse {
         response.count = item.getCount();
         response.salesStartAt = item.getSalesStartAt();
         response.salesEndAt = item.getSalesEndAt();
+        response.imageUrls = imageUrls;
+        response.mainIndex = mainIndex;
         response.tags = tagNames;
         return response;
     }

--- a/src/main/java/com/example/place/domain/item/entity/Item.java
+++ b/src/main/java/com/example/place/domain/item/entity/Item.java
@@ -106,4 +106,8 @@ public class Item extends BaseEntity {
 		this.itemTags.add(itemTag);
 		itemTag.setItem(this);
 	}
+
+	public void addImage(Image image) {
+		this.images.add(image);
+	}
 }

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -12,7 +12,6 @@ import com.example.place.domain.tag.entity.Tag;
 import com.example.place.domain.tag.repository.TagRepository;
 
 import com.example.place.domain.user.entity.User;
-import com.example.place.domain.user.repository.UserRepository;
 import com.example.place.domain.user.service.UserService;
 import org.springframework.stereotype.Service;
 
@@ -80,7 +79,7 @@ public class ItemService {
         itemRepository.save(item);
 
 		// 연관 이미지 저장
-		imageService.saveImages(item, request.getImages(), request.getMainIndex());
+		imageService.saveImages(item, request.getImageUrls(), request.getMainIndex());
 
 		//	태그 저장 로직
         for (String tagName: request.getItemTagNames()) {
@@ -110,13 +109,13 @@ public class ItemService {
 		item.updateItem(request);
 
 		// 연관 이미지 수정
-		if ((request.getImages() == null && request.getMainIndex() != null)
-			|| (request.getImages() != null && request.getMainIndex() == null)) {
+		if ((request.getImageUrls() == null && request.getMainIndex() != null)
+			|| (request.getImageUrls() != null && request.getMainIndex() == null)) {
 			throw new CustomException(ExceptionCode.INVALID_IMAGE_UPDATE_REQUEST);
 		}
 
-		if (request.getImages() != null && request.getMainIndex() != null) {
-			imageService.updateImages(item, request.getImages(), request.getMainIndex());
+		if (request.getImageUrls() != null && request.getMainIndex() != null) {
+			imageService.updateImages(item, request.getImageUrls(), request.getMainIndex());
 		}
 
 		return ItemResponse.from(item);


### PR DESCRIPTION
## 개요
상품 응답값에 이미지 url 목록과 대표이미지를 포함하도록 추가

## 작업 사항
- 상품 응답값에 이미지 url 목록과 대표이미지를 포함
- 이미지 저장 시 상품의 이미지 리스트에도 수동으로 값 입력 (정상적인 응답값 반환을 위해)
- 명칭 통일을 위해 Item 패키지의 images -> imageUrls로 변경

## 리뷰 요청 포인트
로직 흐름 자연스러운지 확인 부탁드립니다.
누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #119
- 참고 자료: [링크]

---
