### PR TITLE
feat : 회원 태그 저장 및 수정기능 추가

### DIFF
--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -91,6 +91,7 @@ public class ItemService {
 
 			item.addItemTag(itemTag);
         }
+
         return ItemResponse.from(item);
     }
 

--- a/src/main/java/com/example/place/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/example/place/domain/user/dto/UserRegisterRequest.java
@@ -1,5 +1,8 @@
 package com.example.place.domain.user.dto;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -26,7 +29,8 @@ public class UserRegisterRequest {
 
 	private final String imageUrl;
 
-	// private final String tags;
+	@Size(max = 5, message = "태그는 최대 5개까지 등록할 수 있습니다.")
+	private final Set<@Size(max = 70, message = "태그명은 70자를 초과할 수 없습니다.")String> tags = new HashSet<>();
 
 	public UserRegisterRequest(String name, String nickname, String email, String password, String imageUrl) {
 		this.name = name;

--- a/src/main/java/com/example/place/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/place/domain/user/dto/UserResponse.java
@@ -1,5 +1,7 @@
 package com.example.place.domain.user.dto;
 
+import java.util.List;
+
 import com.example.place.domain.user.entity.User;
 
 import lombok.Getter;
@@ -11,13 +13,15 @@ public class UserResponse {
 	private final String nickname;
 	private final String imageUrl;
 	private final String email;
+	private final List<String> tags;
 
-	private UserResponse(Long id, String name, String nickname, String imageUrl, String email) {
+	private UserResponse(Long id, String name, String nickname, String imageUrl, String email, List<String> tags) {
 		this.id = id;
 		this.name = name;
 		this.nickname = nickname;
 		this.imageUrl = imageUrl;
 		this.email = email;
+		this.tags = tags;
 	}
 
 	public static UserResponse from(User user) {
@@ -26,7 +30,10 @@ public class UserResponse {
 			user.getName(),
 			user.getNickname(),
 			user.getImageUrl(),
-			user.getEmail()
+			user.getEmail(),
+			user.getUserTags().stream()
+				.map(userTag -> userTag.getTag().getTagName())
+				.toList()
 		);
 	}
 }

--- a/src/main/java/com/example/place/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/place/domain/user/dto/UserUpdateRequest.java
@@ -1,5 +1,8 @@
 package com.example.place.domain.user.dto;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -9,8 +12,9 @@ public class UserUpdateRequest {
 	private final String name;
 	@Size(min = 2, max = 30, message = "2자 이상 30자 이하로 입력해주세요.")
 	private final String nickname;
-	// private final String tags;
 	private final String imageUrl;
+	@Size(max = 5, message = "태그는 최대 5개까지 등록할 수 있습니다.")
+	private final Set<@Size(max = 70, message = "태그명은 70자를 초과할 수 없습니다.")String> tags = new HashSet<>();
 
 	public UserUpdateRequest(String name, String nickname, String imageUrl) {
 		this.name = name;

--- a/src/main/java/com/example/place/domain/user/entity/User.java
+++ b/src/main/java/com/example/place/domain/user/entity/User.java
@@ -1,7 +1,12 @@
 package com.example.place.domain.user.entity;
 
-import com.example.place.common.entity.SoftDeleteEntity;
+import java.util.ArrayList;
+import java.util.List;
 
+import com.example.place.common.entity.SoftDeleteEntity;
+import com.example.place.domain.usertag.entity.UserTag;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +14,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -36,7 +42,10 @@ public class User extends SoftDeleteEntity {
 	private String imageUrl;
 	@Enumerated(EnumType.STRING)
 	private UserRole role;
-	//private String tags;
+
+	@OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
+	private List<UserTag> userTags = new ArrayList<>();
+
 
 	private User(String name, String nickname, String email, String password, String imageUrl,
 		UserRole role) {
@@ -60,5 +69,10 @@ public class User extends SoftDeleteEntity {
 
 	public static User of(String name,String nickname,String email,String password , String imageUrl,UserRole role){
 		return new User(name,nickname,email,password,imageUrl,role);
+	}
+
+	// 태그 추가 메서드
+	public void addUserTag(UserTag userTag) {
+		this.userTags.add(userTag);
 	}
 }

--- a/src/main/java/com/example/place/domain/user/service/UserService.java
+++ b/src/main/java/com/example/place/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.place.domain.user.service;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -8,6 +9,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
+import com.example.place.domain.tag.entity.Tag;
+import com.example.place.domain.tag.repository.TagRepository;
 import com.example.place.domain.user.dto.UserDeleteRequest;
 import com.example.place.domain.user.dto.UserPasswordRequest;
 import com.example.place.domain.user.dto.UserRegisterRequest;
@@ -17,9 +20,8 @@ import com.example.place.domain.user.dto.UserUpdateRequest;
 import com.example.place.domain.user.entity.User;
 import com.example.place.domain.user.entity.UserRole;
 import com.example.place.domain.user.repository.UserRepository;
+import com.example.place.domain.usertag.entity.UserTag;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -27,7 +29,9 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
+	private final TagRepository tagRepository;
 
+	@Transactional
 	public UserRegisterResponse register(UserRegisterRequest userRegisterRequest, UserRole userRole) {
 		// 이메일 중복 검증
 		if (userRepository.existsByEmail(userRegisterRequest.getEmail())) {
@@ -50,6 +54,8 @@ public class UserService {
 		);
 
 		User savedUser = userRepository.save(user);
+
+		saveTags(savedUser, userRegisterRequest.getTags());
 
 		return new UserRegisterResponse(savedUser.getEmail());
 	}
@@ -80,6 +86,8 @@ public class UserService {
 			userUpdateRequest.getName(),
 			userUpdateRequest.getNickname(),
 			userUpdateRequest.getImageUrl());
+
+		updateUserTags(foundUser, userUpdateRequest.getTags());
 
 		return UserResponse.from(foundUser);
 	}
@@ -123,6 +131,25 @@ public class UserService {
 		foundUser.delete();
 
 		return null;
+	}
+
+	// 태그 업데이트 메서드
+	private void updateUserTags(User user, Set<String> newTagNames) {
+		// 기존 태그 모두 제거 (orphanRemoval = true 설정되어 있다면 자동 삭제)
+		user.getUserTags().clear();
+		saveTags(user, newTagNames);
+	}
+
+	// 태그 저장 메서드
+	private void saveTags(User user, Set<String> tagNames) {
+		for (String tagName: tagNames) {
+			Tag tag = tagRepository.findByTagName(tagName)
+				.orElseGet(() -> tagRepository.save(new Tag(tagName)));
+
+			UserTag userTag = UserTag.of(tag, user);
+
+			user.addUserTag(userTag);
+		}
 	}
 
 	public User findUserById(Long userId) {

--- a/src/main/java/com/example/place/domain/usertag/entity/UserTag.java
+++ b/src/main/java/com/example/place/domain/usertag/entity/UserTag.java
@@ -4,13 +4,13 @@ import com.example.place.domain.tag.entity.Tag;
 import com.example.place.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user_tags")
+@Getter
 public class UserTag {
 
     @Id
@@ -25,4 +25,18 @@ public class UserTag {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    private UserTag(Tag tag, User user) {
+        this.tag = tag;
+        this.user = user;
+    }
+
+    public static UserTag of(Tag tag, User user) {
+        return new UserTag(tag,user);
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
 }
+


### PR DESCRIPTION
## 개요
회원 태그 저장 및 수정기능 추가

## 작업 사항
1. User 엔티티 Tags 필드 추가
2. RegisterRequest DTO 수정
3. UserResponse DTO 수정
4. UserUpdateRequest DTO 수정
5. UserService -> register 메소드 로직에서 태그 저장 로직 추가
6. UserService -> update 메소드 로직에서 태그 수정 로직 추가
7. 태그 제한 및 예외처리 ( 태그는 최대 5개, 태그당 70자 제한으로 결정 )
8. 태그 중복 처리 ( DTO에서 tags를 List -> Set으로 변경 )

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #126 

---
