### PR TITLE
feat: 게시글에서 상품 이미지url목록과 대표이미지를 가져와 함께 반환하도록 추가 + 리팩토링

### DIFF
--- a/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
@@ -3,9 +3,14 @@ package com.example.place.domain.Image.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.place.domain.Image.entity.Image;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findByItemId(Long itemId);
+
+	@Query("SELECT i FROM Image i WHERE i.item.id IN :itemIds")
+	List<Image> findByItemIds(@Param("itemIds") List<Long> itemIds);
 }

--- a/src/main/java/com/example/place/domain/Image/service/ImageService.java
+++ b/src/main/java/com/example/place/domain/Image/service/ImageService.java
@@ -95,4 +95,9 @@ public class ImageService {
 			|| mainIndex >= listSize)
 			? 0 : mainIndex;
 	}
+
+	@Transactional
+	public List<Image> findByItemIds(List<Long> itemIds) {
+		return imageRepository.findByItemIds(itemIds);
+	}
 }

--- a/src/main/java/com/example/place/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/place/domain/post/controller/PostController.java
@@ -1,6 +1,5 @@
 package com.example.place.domain.post.controller;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -46,21 +45,19 @@ public class PostController {
 
 	//살까말까 단건 조회
 	@GetMapping("/{postId}")
-	public ResponseEntity<ApiResponseDto<PostWithUserResponseDto>> readPost(
-		@PathVariable Long postId,
-		@AuthenticationPrincipal CustomPrincipal principal
+	public ResponseEntity<ApiResponseDto<PostWithUserResponseDto>> getPost(
+		@PathVariable Long postId
 	) {
-		PostWithUserResponseDto post = postService.readPost(postId,principal.getId());
+		PostWithUserResponseDto post = postService.getPost(postId);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 조회가 완료되었습니다.", post));
 	}
 
 	//살까말까 전체 조회
 	@GetMapping
 	public ResponseEntity<ApiResponseDto<PageResponseDto<PostWithUserResponseDto>>> getAllPosts(
-		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
-		@AuthenticationPrincipal CustomPrincipal principal
+		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
 	) {
-		PageResponseDto<PostWithUserResponseDto> posts = postService.getAllPosts(pageable, principal.getId());
+		PageResponseDto<PostWithUserResponseDto> posts = postService.getAllPosts(pageable);
 		return ResponseEntity.ok(ApiResponseDto.of("성공", posts));
 	}
 

--- a/src/main/java/com/example/place/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/place/domain/post/controller/PostController.java
@@ -1,7 +1,6 @@
 package com.example.place.domain.post.controller;
 
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +19,7 @@ import com.example.place.common.dto.PageResponseDto;
 import com.example.place.common.security.jwt.CustomPrincipal;
 import com.example.place.domain.post.dto.request.PostCreateRequestDto;
 import com.example.place.domain.post.dto.request.PostUpdateRequestDto;
-import com.example.place.domain.post.dto.response.PostWithUserResponseDto;
+import com.example.place.domain.post.dto.response.PostResponseDto;
 import com.example.place.domain.post.service.PostService;
 
 import jakarta.validation.Valid;
@@ -35,50 +34,50 @@ public class PostController {
 
 	//살까말까 생성
 	@PostMapping
-	public ResponseEntity<ApiResponseDto<PostWithUserResponseDto>> createPost(
+	public ResponseEntity<ApiResponseDto<PostResponseDto>> createPost(
 		@Valid @RequestBody PostCreateRequestDto request,
 		@AuthenticationPrincipal CustomPrincipal principal
 	) {
-		PostWithUserResponseDto post = postService.createPost(principal.getId(), request);
+		PostResponseDto post = postService.createPost(principal.getId(), request);
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponseDto.of("게시글 등록이 완료되었습니다.", post));
 	}
 
 	//살까말까 단건 조회
 	@GetMapping("/{postId}")
-	public ResponseEntity<ApiResponseDto<PostWithUserResponseDto>> getPost(
+	public ResponseEntity<ApiResponseDto<PostResponseDto>> getPost(
 		@PathVariable Long postId
 	) {
-		PostWithUserResponseDto post = postService.getPost(postId);
+		PostResponseDto post = postService.getPost(postId);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 조회가 완료되었습니다.", post));
 	}
 
 	//살까말까 전체 조회
 	@GetMapping
-	public ResponseEntity<ApiResponseDto<PageResponseDto<PostWithUserResponseDto>>> getAllPosts(
+	public ResponseEntity<ApiResponseDto<PageResponseDto<PostResponseDto>>> getAllPosts(
 		@PageableDefault Pageable pageable
 	) {
-		PageResponseDto<PostWithUserResponseDto> posts = postService.getAllPosts(pageable);
+		PageResponseDto<PostResponseDto> posts = postService.getAllPosts(pageable);
 		return ResponseEntity.ok(ApiResponseDto.of("성공", posts));
 	}
 
 	//살까말까 내 글 조회
 	@GetMapping("/me")
-	public ResponseEntity<ApiResponseDto<PageResponseDto<PostWithUserResponseDto>>> getMyPosts(
+	public ResponseEntity<ApiResponseDto<PageResponseDto<PostResponseDto>>> getMyPosts(
 		@PageableDefault Pageable pageable,
 		@AuthenticationPrincipal CustomPrincipal principal
 	) {
-		PageResponseDto<PostWithUserResponseDto> posts = postService.findMyPosts(principal.getId(), pageable);
+		PageResponseDto<PostResponseDto> posts = postService.findMyPosts(principal.getId(), pageable);
 		return ResponseEntity.ok(ApiResponseDto.of("성공", posts));
 	}
 
 	//살까말까 수정
 	@PatchMapping("/{postId}")
-	public ResponseEntity<ApiResponseDto<PostWithUserResponseDto>> updatePost(
+	public ResponseEntity<ApiResponseDto<PostResponseDto>> updatePost(
 		@PathVariable Long postId,
 		@Valid @RequestBody PostUpdateRequestDto request,
 		@AuthenticationPrincipal CustomPrincipal principal
 	) {
-		PostWithUserResponseDto updatePost = postService.updatePost(postId, request, principal.getId());
+		PostResponseDto updatePost = postService.updatePost(postId, request, principal.getId());
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 수정이 완료되었습니다.", updatePost));
 	}
 

--- a/src/main/java/com/example/place/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/place/domain/post/controller/PostController.java
@@ -55,7 +55,7 @@ public class PostController {
 	//살까말까 전체 조회
 	@GetMapping
 	public ResponseEntity<ApiResponseDto<PageResponseDto<PostWithUserResponseDto>>> getAllPosts(
-		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+		@PageableDefault Pageable pageable
 	) {
 		PageResponseDto<PostWithUserResponseDto> posts = postService.getAllPosts(pageable);
 		return ResponseEntity.ok(ApiResponseDto.of("성공", posts));
@@ -64,7 +64,7 @@ public class PostController {
 	//살까말까 내 글 조회
 	@GetMapping("/me")
 	public ResponseEntity<ApiResponseDto<PageResponseDto<PostWithUserResponseDto>>> getMyPosts(
-		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+		@PageableDefault Pageable pageable,
 		@AuthenticationPrincipal CustomPrincipal principal
 	) {
 		PageResponseDto<PostWithUserResponseDto> posts = postService.findMyPosts(principal.getId(), pageable);

--- a/src/main/java/com/example/place/domain/post/dto/request/PostCreateRequestDto.java
+++ b/src/main/java/com/example/place/domain/post/dto/request/PostCreateRequestDto.java
@@ -12,6 +12,4 @@ public class PostCreateRequestDto {
 
 	@NotBlank(message = "내용을 입력해주세요.")
 	private String content;
-
-	private String image;
 }

--- a/src/main/java/com/example/place/domain/post/dto/request/PostUpdateRequestDto.java
+++ b/src/main/java/com/example/place/domain/post/dto/request/PostUpdateRequestDto.java
@@ -5,5 +5,4 @@ import lombok.Getter;
 @Getter
 public class PostUpdateRequestDto {
 	private String content;
-	private String image;
 }

--- a/src/main/java/com/example/place/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/place/domain/post/dto/response/PostResponseDto.java
@@ -9,7 +9,7 @@ import com.example.place.domain.post.entity.Post;
 import lombok.Getter;
 
 @Getter
-public class PostWithUserResponseDto {
+public class PostResponseDto {
 	private final Long id;
 	private final String content;
 	private final String nickname;
@@ -17,7 +17,7 @@ public class PostWithUserResponseDto {
 	private List<String> imageUrls;
 	private int mainIndex;
 
-	private PostWithUserResponseDto(Long id, String content, String nickname, Long itemId, List<String> imageUrls,
+	private PostResponseDto(Long id, String content, String nickname, Long itemId, List<String> imageUrls,
 		int mainIndex) {
 		this.id = id;
 		this.content = content;
@@ -27,7 +27,7 @@ public class PostWithUserResponseDto {
 		this.mainIndex = mainIndex;
 	}
 
-	public static PostWithUserResponseDto from(Post post) {
+	public static PostResponseDto from(Post post) {
 		List<Image> images = post.getItem().getImages();
 		List<String> imageUrls = new ArrayList<>();
 		int mainIndex = 0;
@@ -38,7 +38,25 @@ public class PostWithUserResponseDto {
 			}
 		}
 
-		return new PostWithUserResponseDto(post.getId(),
+		return new PostResponseDto(post.getId(),
+			post.getContent(),
+			post.getUser().getNickname(),
+			post.getItem().getId(),
+			imageUrls,
+			mainIndex);
+	}
+
+	public static PostResponseDto fromWithImages(Post post, List<Image> images) {
+		List<String> imageUrls = new ArrayList<>();
+		int mainIndex = 0;
+		for (int i = 0; i < images.size(); i++) {
+			imageUrls.add(images.get(i).getImageUrl());
+			if (images.get(i).isMain()) {
+				mainIndex = i;
+			}
+		}
+
+		return new PostResponseDto(post.getId(),
 			post.getContent(),
 			post.getUser().getNickname(),
 			post.getItem().getId(),

--- a/src/main/java/com/example/place/domain/post/dto/response/PostWithUserResponseDto.java
+++ b/src/main/java/com/example/place/domain/post/dto/response/PostWithUserResponseDto.java
@@ -1,5 +1,9 @@
 package com.example.place.domain.post.dto.response;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.post.entity.Post;
 
 import lombok.Getter;
@@ -10,11 +14,25 @@ public class PostWithUserResponseDto {
 	private final String content;
 	private final String nickname;
 	private final Long itemId;
+	private List<String> imageUrls;
+	private int mainIndex;
 
 	public PostWithUserResponseDto(Post post,String nickname) {
+		List<Image> images = post.getItem().getImages();
+		List<String> imageUrls = new ArrayList<>();
+		int mainIndex = 0;
+		for (int i = 0; i < images.size(); i++) {
+			imageUrls.add(images.get(i).getImageUrl());
+			if (images.get(i).isMain()) {
+				mainIndex = i;
+			}
+		}
+
 		this.id = post.getId();
 		this.content = post.getContent();
-		this.itemId = post.getItem().getId();
 		this.nickname = nickname;
+		this.itemId = post.getItem().getId();
+		this.imageUrls = imageUrls;
+		this.mainIndex = mainIndex;
 	}
 }

--- a/src/main/java/com/example/place/domain/post/dto/response/PostWithUserResponseDto.java
+++ b/src/main/java/com/example/place/domain/post/dto/response/PostWithUserResponseDto.java
@@ -8,14 +8,12 @@ import lombok.Getter;
 public class PostWithUserResponseDto {
 	private final Long id;
 	private final String content;
-	private final String image;
 	private final String nickname;
 	private final Long itemId;
 
 	public PostWithUserResponseDto(Post post,String nickname) {
 		this.id = post.getId();
 		this.content = post.getContent();
-		this.image = post.getImage();
 		this.itemId = post.getItem().getId();
 		this.nickname = nickname;
 	}

--- a/src/main/java/com/example/place/domain/post/dto/response/PostWithUserResponseDto.java
+++ b/src/main/java/com/example/place/domain/post/dto/response/PostWithUserResponseDto.java
@@ -17,7 +17,17 @@ public class PostWithUserResponseDto {
 	private List<String> imageUrls;
 	private int mainIndex;
 
-	public PostWithUserResponseDto(Post post,String nickname) {
+	private PostWithUserResponseDto(Long id, String content, String nickname, Long itemId, List<String> imageUrls,
+		int mainIndex) {
+		this.id = id;
+		this.content = content;
+		this.nickname = nickname;
+		this.itemId = itemId;
+		this.imageUrls = imageUrls;
+		this.mainIndex = mainIndex;
+	}
+
+	public static PostWithUserResponseDto from(Post post) {
 		List<Image> images = post.getItem().getImages();
 		List<String> imageUrls = new ArrayList<>();
 		int mainIndex = 0;
@@ -28,11 +38,12 @@ public class PostWithUserResponseDto {
 			}
 		}
 
-		this.id = post.getId();
-		this.content = post.getContent();
-		this.nickname = nickname;
-		this.itemId = post.getItem().getId();
-		this.imageUrls = imageUrls;
-		this.mainIndex = mainIndex;
+		return new PostWithUserResponseDto(post.getId(),
+			post.getContent(),
+			post.getUser().getNickname(),
+			post.getItem().getId(),
+			imageUrls,
+			mainIndex);
 	}
+
 }

--- a/src/main/java/com/example/place/domain/post/entity/Post.java
+++ b/src/main/java/com/example/place/domain/post/entity/Post.java
@@ -1,5 +1,6 @@
 package com.example.place.domain.post.entity;
 
+import com.example.place.common.entity.BaseEntity;
 import com.example.place.domain.item.entity.Item;
 import com.example.place.domain.user.entity.User;
 
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "posts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post {
+public class Post extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/place/domain/post/entity/Post.java
+++ b/src/main/java/com/example/place/domain/post/entity/Post.java
@@ -36,21 +36,17 @@ public class Post {
 	@Lob
 	private String content;
 
-	private String image;
-
-	private Post(User user, Item item, String content, String image) {
+	private Post(User user, Item item, String content) {
 		this.user = user;
 		this.item = item;
 		this.content = content;
-		this.image = image;
 	}
 
-	public static Post of(User user, Item item, String content, String image){
-		return new Post(user, item, content, image);
+	public static Post of(User user, Item item, String content) {
+		return new Post(user, item, content);
 	}
 
-	public void update(String content, String image) {
+	public void update(String content) {
 		this.content = content;
-		this.image = image;
 	}
 }

--- a/src/main/java/com/example/place/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/place/domain/post/repository/PostRepository.java
@@ -1,15 +1,33 @@
 package com.example.place.domain.post.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.post.entity.Post;
 import com.example.place.domain.user.entity.User;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-	Page<Post> findAllByUser(User user, Pageable pageable);
+	@Query(
+		value = "SELECT DISTINCT p FROM Post p " +
+			"JOIN FETCH p.user " +
+			"JOIN FETCH p.item ",
+		countQuery = "SELECT COUNT(p) FROM Post p"
+	)
+	Page<Post> findAll(Pageable pageable);
 
+	@Query(
+		value = "SELECT DISTINCT p FROM Post p " +
+			"JOIN FETCH p.user u " +
+			"JOIN FETCH p.item " +
+			"WHERE u = :user",
+		countQuery = "SELECT COUNT(p) FROM Post p WHERE p.user = :user"
+	)
+	Page<Post> findAllByUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/example/place/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/example/place/domain/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package com.example.place.domain.post.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.example.place.domain.post.entity.Post;
 import com.example.place.domain.user.entity.User;

--- a/src/main/java/com/example/place/domain/post/service/PostService.java
+++ b/src/main/java/com/example/place/domain/post/service/PostService.java
@@ -33,7 +33,7 @@ public class PostService {
 		User user = userService.findByIdOrElseThrow(userId);
 		Item item = itemService.findByIdOrElseThrow(request.getItemId());
 
-		Post post = Post.of(user, item, request.getContent(), request.getImage());
+		Post post = Post.of(user, item, request.getContent());
 		Post saved = postRepository.save(post);
 
 		return new PostWithUserResponseDto(saved,user.getNickname());
@@ -83,7 +83,7 @@ public class PostService {
 			throw new CustomException(ExceptionCode.FORBIDDEN_POST_ACCESS);
 		}
 
-		post.update(request.getContent(), request.getImage());
+		post.update(request.getContent());
 		return new PostWithUserResponseDto(post,user.getNickname());
 	}
 

--- a/src/main/java/com/example/place/domain/post/service/PostService.java
+++ b/src/main/java/com/example/place/domain/post/service/PostService.java
@@ -36,25 +36,21 @@ public class PostService {
 		Post post = Post.of(user, item, request.getContent());
 		Post saved = postRepository.save(post);
 
-		return new PostWithUserResponseDto(saved,user.getNickname());
+		return PostWithUserResponseDto.from(saved);
 	}
 
 	//살까말까 단건 조회
-	public PostWithUserResponseDto readPost(Long postId,Long userId) {
-		User user = userService.findByIdOrElseThrow(userId);
+	public PostWithUserResponseDto getPost(Long postId) {
 		Post post = findByIdOrElseThrow(postId);
-		return new PostWithUserResponseDto(post,user.getNickname());
+		return PostWithUserResponseDto.from(post);
 	}
 
 	//살까말까 전체 조회
-	public PageResponseDto<PostWithUserResponseDto> getAllPosts(Pageable pageable, Long userId) {
-		User user = userService.findByIdOrElseThrow(userId);
+	public PageResponseDto<PostWithUserResponseDto> getAllPosts(Pageable pageable) {
 
 		Page<Post> postsPage = postRepository.findAll(pageable);
 
-		Page<PostWithUserResponseDto> dtoPage = postsPage.map(post ->
-			new PostWithUserResponseDto(post, user.getNickname())
-		);
+		Page<PostWithUserResponseDto> dtoPage = postsPage.map(PostWithUserResponseDto::from);
 
 		return new PageResponseDto<>(dtoPage);
 	}
@@ -66,9 +62,7 @@ public class PostService {
 
 		Page<Post> postsPage = postRepository.findAllByUser(user,pageable);
 
-		Page<PostWithUserResponseDto> dtoPage = postsPage.map(post ->
-			new PostWithUserResponseDto(post,user.getNickname())
-		);
+		Page<PostWithUserResponseDto> dtoPage = postsPage.map(PostWithUserResponseDto::from);
 
 		return new PageResponseDto<>(dtoPage);
 	}
@@ -76,7 +70,6 @@ public class PostService {
 	//살까말까 수정
 	@Transactional
 	public PostWithUserResponseDto updatePost(Long postId, PostUpdateRequestDto request, Long userId) {
-		User user = userService.findByIdOrElseThrow(userId);
 		Post post = findByIdOrElseThrow(postId);
 
 		if (!post.getUser().getId().equals(userId)) {
@@ -84,7 +77,7 @@ public class PostService {
 		}
 
 		post.update(request.getContent());
-		return new PostWithUserResponseDto(post,user.getNickname());
+		return PostWithUserResponseDto.from(post);
 	}
 
 	//살까말까 삭제

--- a/src/main/java/com/example/place/domain/post/service/PostService.java
+++ b/src/main/java/com/example/place/domain/post/service/PostService.java
@@ -29,6 +29,7 @@ public class PostService {
 	private final ItemService itemService;
 
 	//살까말까 생성
+	@Transactional
 	public PostWithUserResponseDto createPost(Long userId, PostCreateRequestDto request) {
 		User user = userService.findByIdOrElseThrow(userId);
 		Item item = itemService.findByIdOrElseThrow(request.getItemId());
@@ -40,12 +41,14 @@ public class PostService {
 	}
 
 	//살까말까 단건 조회
+	@Transactional(readOnly = true)
 	public PostWithUserResponseDto getPost(Long postId) {
 		Post post = findByIdOrElseThrow(postId);
 		return PostWithUserResponseDto.from(post);
 	}
 
 	//살까말까 전체 조회
+	@Transactional(readOnly = true)
 	public PageResponseDto<PostWithUserResponseDto> getAllPosts(Pageable pageable) {
 
 		Page<Post> postsPage = postRepository.findAll(pageable);
@@ -57,6 +60,7 @@ public class PostService {
 
 
 	//살까말까 내 글 조회
+	@Transactional(readOnly = true)
 	public PageResponseDto<PostWithUserResponseDto> findMyPosts(Long userId, Pageable pageable) {
 		User user = userService.findByIdOrElseThrow(userId);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     #    hibernate.ddl-auto: create
     hibernate.ddl-auto: update
-    show-sql: false
+    show-sql: true
     properties:
       hibernate:
         format_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     #    hibernate.ddl-auto: create
     hibernate.ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 개요
게시글에서 상품 이미지url목록과 대표이미지를 가져와 함께 반환하도록 추가 및 리팩토링

## 작업 사항
- 게시글에서 상품 이미지url목록과 대표이미지를 가져와 함께 반환하도록 추가
- 생성자에서 팩토리 메서드 사용하도록 변경
- 불필요한 로직 삭제
- @Transactional 추가
- pageable 설정 삭제

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #174 
- 참고 자료: [링크]

---
