### PR TITLE
refactor : Tag 관련 로직을 TagService로 옮겨서 UserService의 의존성 정리

### DIFF
--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -90,7 +90,7 @@ public class ItemService {
             Tag tag = tagRepository.findByTagName(tagName)
                     .orElseGet(() -> tagRepository.save(Tag.of(tagName)));
 
-            ItemTag itemTag = new ItemTag(null, item, tag);
+            ItemTag itemTag = ItemTag.of(tag, item);
 
 			item.addItemTag(itemTag);
         }

--- a/src/main/java/com/example/place/domain/itemtag/entity/ItemTag.java
+++ b/src/main/java/com/example/place/domain/itemtag/entity/ItemTag.java
@@ -16,7 +16,6 @@ public class ItemTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter
 	@JoinColumn(name = "item_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;
@@ -32,5 +31,9 @@ public class ItemTag {
 
     public static ItemTag of(Tag tag, Item item) {
         return new ItemTag(tag,item);
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
     }
 }

--- a/src/main/java/com/example/place/domain/itemtag/entity/ItemTag.java
+++ b/src/main/java/com/example/place/domain/itemtag/entity/ItemTag.java
@@ -2,13 +2,11 @@ package com.example.place.domain.itemtag.entity;
 
 import com.example.place.domain.item.entity.Item;
 import com.example.place.domain.tag.entity.Tag;
-import com.example.place.domain.user.entity.User;
 import jakarta.persistence.*;
 
 import lombok.*;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "item_tags")
@@ -18,7 +16,8 @@ public class ItemTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @JoinColumn(name = "item_id")
+    @Setter
+	@JoinColumn(name = "item_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Item item;
 
@@ -26,8 +25,12 @@ public class ItemTag {
     @ManyToOne(fetch = FetchType.LAZY)
     private Tag tag;
 
-    public void setItem(Item item) {
+    private ItemTag(Tag tag, Item item) {
+        this.tag = tag;
         this.item = item;
     }
 
+    public static ItemTag of(Tag tag, Item item) {
+        return new ItemTag(tag,item);
+    }
 }

--- a/src/main/java/com/example/place/domain/tag/service/TagService.java
+++ b/src/main/java/com/example/place/domain/tag/service/TagService.java
@@ -1,11 +1,17 @@
 package com.example.place.domain.tag.service;
 
+import java.util.Set;
+
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
 import com.example.place.domain.tag.dto.request.TagRequest;
 import com.example.place.domain.tag.dto.response.TagResponse;
 import com.example.place.domain.tag.entity.Tag;
 import com.example.place.domain.tag.repository.TagRepository;
+import com.example.place.domain.user.entity.User;
+import com.example.place.domain.usertag.entity.UserTag;
+import com.example.place.domain.item.entity.Item;
+import com.example.place.domain.itemtag.entity.ItemTag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,9 +59,30 @@ public class TagService {
         tagRepository.delete(tag);
     }
 
+    // 유저 태그 저장 메서드
+    public void saveTags(User user, Set<String> tagNames) {
+        for (String tagName: tagNames) {
+            Tag tag = findOrCreateTag(tagName);
+            user.addUserTag(UserTag.of(tag, user));
+        }
+    }
+
+    // 아이템 태그 저장 메서드
+    public void saveTags(Item item, Set<String> tagNames) {
+        for (String tagName: tagNames) {
+            Tag tag = findOrCreateTag(tagName);
+            item.addItemTag(ItemTag.of(tag, item));
+        }
+    }
+
     public Tag findByIdOrElseThrow(Long tagId) {
         return tagRepository.findById(tagId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_TAG));
+    }
+
+    public Tag findOrCreateTag(String tagName) {
+        return tagRepository.findByTagName(tagName)
+            .orElseGet(() -> tagRepository.save(Tag.of(tagName)));
     }
 
 }

--- a/src/main/java/com/example/place/domain/user/service/UserService.java
+++ b/src/main/java/com/example/place/domain/user/service/UserService.java
@@ -1,7 +1,6 @@
 package com.example.place.domain.user.service;
 
 import java.util.Optional;
-import java.util.Set;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -9,8 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
-import com.example.place.domain.tag.entity.Tag;
-import com.example.place.domain.tag.repository.TagRepository;
+import com.example.place.domain.tag.service.TagService;
 import com.example.place.domain.user.dto.UserDeleteRequest;
 import com.example.place.domain.user.dto.UserPasswordRequest;
 import com.example.place.domain.user.dto.UserRegisterRequest;
@@ -20,7 +18,6 @@ import com.example.place.domain.user.dto.UserUpdateRequest;
 import com.example.place.domain.user.entity.User;
 import com.example.place.domain.user.entity.UserRole;
 import com.example.place.domain.user.repository.UserRepository;
-import com.example.place.domain.usertag.entity.UserTag;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
-	private final TagRepository tagRepository;
+	private final TagService tagService;
 
 	@Transactional
 	public UserRegisterResponse register(UserRegisterRequest userRegisterRequest, UserRole userRole) {
@@ -55,7 +52,7 @@ public class UserService {
 
 		User savedUser = userRepository.save(user);
 
-		saveTags(savedUser, userRegisterRequest.getTags());
+		tagService.saveTags(savedUser, userRegisterRequest.getTags());
 
 		return new UserRegisterResponse(savedUser.getEmail());
 	}
@@ -87,7 +84,9 @@ public class UserService {
 			userUpdateRequest.getNickname(),
 			userUpdateRequest.getImageUrl());
 
-		updateUserTags(foundUser, userUpdateRequest.getTags());
+		// 현재 유저태그 테이블을 전부 비운뒤에 태그를 새로 저장함
+		foundUser.getUserTags().clear();
+		tagService.saveTags(foundUser, userUpdateRequest.getTags());
 
 		return UserResponse.from(foundUser);
 	}
@@ -131,25 +130,6 @@ public class UserService {
 		foundUser.delete();
 
 		return null;
-	}
-
-	// 태그 업데이트 메서드
-	private void updateUserTags(User user, Set<String> newTagNames) {
-		// 기존 태그 모두 제거 (orphanRemoval = true 설정되어 있다면 자동 삭제)
-		user.getUserTags().clear();
-		saveTags(user, newTagNames);
-	}
-
-	// 태그 저장 메서드
-	private void saveTags(User user, Set<String> tagNames) {
-		for (String tagName: tagNames) {
-			Tag tag = tagRepository.findByTagName(tagName)
-				.orElseGet(() -> tagRepository.save(Tag.of(tagName)));
-
-			UserTag userTag = UserTag.of(tag, user);
-
-			user.addUserTag(userTag);
-		}
 	}
 
 	public User findByIdOrElseThrow(Long userId) {

--- a/src/main/java/com/example/place/domain/usertag/entity/UserTag.java
+++ b/src/main/java/com/example/place/domain/usertag/entity/UserTag.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,7 +21,6 @@ public class UserTag {
     @ManyToOne(fetch = FetchType.LAZY)
     private Tag tag;
 
-    @Setter
 	@JoinColumn(name = "user_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
@@ -36,5 +34,8 @@ public class UserTag {
         return new UserTag(tag,user);
     }
 
+    public void setUser(User user) {
+        this.user = user;
+    }
 }
 

--- a/src/main/java/com/example/place/domain/usertag/entity/UserTag.java
+++ b/src/main/java/com/example/place/domain/usertag/entity/UserTag.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,7 +22,8 @@ public class UserTag {
     @ManyToOne(fetch = FetchType.LAZY)
     private Tag tag;
 
-    @JoinColumn(name = "user_id")
+    @Setter
+	@JoinColumn(name = "user_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
@@ -32,10 +34,6 @@ public class UserTag {
 
     public static UserTag of(Tag tag, User user) {
         return new UserTag(tag,user);
-    }
-
-    public void setUser(User user) {
-        this.user = user;
     }
 
 }


### PR DESCRIPTION
## 개요
Tag 관련 로직을 TagService로 옮겨서 UserService의 의존성 정리

## 작업 사항
- [ ] UserService에 있던 saveTags 메소드를 Item,User가 같이 쓸수있게 TagService로 옮김
- [ ] ItemTag 엔티티도 UserTag와 통일성 있게 수정

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.

## 기타 사항
- 관련 이슈: #182

---
