### PR TITLE
feat: 로그인 유저의 좋아요/싫어요 여부 함께 응답

### DIFF
--- a/src/main/java/com/example/place/domain/vote/dto/response/VoteResponseDto.java
+++ b/src/main/java/com/example/place/domain/vote/dto/response/VoteResponseDto.java
@@ -6,13 +6,18 @@ import lombok.Getter;
 public class VoteResponseDto {
 	private Long likeCount;
 	private Long disLikeCount;
+	private boolean isLike;
+	private boolean isDislike;
 
-	private VoteResponseDto(Long likeCount, Long dislikeCount) {
+	private VoteResponseDto(Long likeCount, Long dislikeCount, boolean isLike, boolean isDislike) {
 		this.likeCount = likeCount;
 		this.disLikeCount = dislikeCount;
+		this.isLike = isLike;
+		this.isDislike = isDislike;
+
 	}
 
-	public static VoteResponseDto of(Long likeCount, Long disLikeCount) {
-		return new VoteResponseDto(likeCount, disLikeCount);
+	public static VoteResponseDto of(Long likeCount, Long disLikeCount, boolean isLike, boolean isDislike) {
+		return new VoteResponseDto(likeCount, disLikeCount, isLike, isDislike);
 	}
 }

--- a/src/main/java/com/example/place/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/example/place/domain/vote/repository/VoteRepository.java
@@ -1,8 +1,11 @@
 package com.example.place.domain.vote.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.place.domain.post.entity.Post;
 import com.example.place.domain.user.entity.User;
@@ -12,5 +15,14 @@ import com.example.place.domain.vote.entity.VoteType;
 public interface VoteRepository extends JpaRepository<Vote, Long> {
 	Optional<Vote> findByUserAndPostAndVoteType(User user, Post post, VoteType attr0);
 
-	Long countByPostAndVoteType(Post post, VoteType voteType);
+	@Query("""
+		SELECT
+		    COUNT(CASE WHEN v.voteType = 'LIKE' THEN 1 END),
+		    COUNT(CASE WHEN v.voteType = 'DISLIKE' THEN 1 END),
+		    MAX(CASE WHEN v.voteType = 'LIKE' AND v.user.id = :userId THEN 1 ELSE 0 END),
+		    MAX(CASE WHEN v.voteType = 'DISLIKE' AND v.user.id = :userId THEN 1 ELSE 0 END)
+		FROM Vote v
+		JOIN v.post p
+		WHERE p.id = :postId""")
+	List<Object[]> findVoteStatsByPostIds(@Param("postId") Long postId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/example/place/domain/vote/service/VoteService.java
+++ b/src/main/java/com/example/place/domain/vote/service/VoteService.java
@@ -1,5 +1,6 @@
 package com.example.place.domain.vote.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -48,12 +49,19 @@ public class VoteService {
 		Vote vote = Vote.of(user, post, newVoteType);
 		voteRepository.save(vote);
 
-		// like 개수
-		Long likeCount = voteRepository.countByPostAndVoteType(post, VoteType.LIKE);
-		// dislike 개수
-		Long dislikeCount = voteRepository.countByPostAndVoteType(post, VoteType.DISLIKE);
+		// 응답값 조회
+		Object[] result = voteRepository.findVoteStatsByPostIds(postId, userId).get(0);
 
-		return VoteResponseDto.of(likeCount, dislikeCount);
+		// like 개수
+		Long likeCount = ((Number)result[0]).longValue();
+		// dislike 개수
+		Long dislikeCount = ((Number)result[1]).longValue();
+		// 로그인한 유저의 like 투표 여부
+		boolean isLike = ((Number)result[2]).intValue() == 1;
+		// 로그인한 유저의 dislike 투표 여부
+		boolean isDislike = ((Number)result[3]).intValue() == 1;
+
+		return VoteResponseDto.of(likeCount, dislikeCount, isLike, isDislike);
 	}
 
 	public VoteResponseDto deleteVote(Long postId, @Valid VoteRequestDto request, Long userId) {
@@ -69,11 +77,18 @@ public class VoteService {
 		// 투표 삭제
 		voteRepository.delete(existingVote);
 
-		// like 개수
-		Long likeCount = voteRepository.countByPostAndVoteType(post, VoteType.LIKE);
-		// dislike 개수
-		Long dislikeCount = voteRepository.countByPostAndVoteType(post, VoteType.DISLIKE);
+		// 응답값 조회
+		Object[] result = voteRepository.findVoteStatsByPostIds(postId, userId).get(0);
 
-		return VoteResponseDto.of(likeCount, dislikeCount);
+		// like 개수
+		Long likeCount = ((Number)result[0]).longValue();
+		// dislike 개수
+		Long dislikeCount = ((Number)result[1]).longValue();
+		// 로그인한 유저의 like 투표 여부
+		boolean isLike = ((Number)result[2]).intValue() == 1;
+		// 로그인한 유저의 dislike 투표 여부
+		boolean isDislike = ((Number)result[3]).intValue() == 1;
+
+		return VoteResponseDto.of(likeCount, dislikeCount, isLike, isDislike);
 	}
 }


### PR DESCRIPTION
## 개요
로그인 유저의 좋아요/싫어요 여부 함께 응답

## 작업 사항
- 로그인 유저의 좋아요/싫어요 여부 함께 응답하도록 추가했습니다
- 해당 게시글에 좋아요 수, 싫어요 수, 로그인 유저 기준 좋아요 여부, 싫어요 여부를 한번에 조회하도록 쿼리문을 수정했습니다.

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.

## 기타 사항
- 관련 이슈: #189 
- 참고 자료: [링크]

---
