### PR TITLE
feature : 태그 저장시 정규화(공백, 특수문자 제거)기능 추가

### DIFF
--- a/src/main/java/com/example/place/domain/tag/service/TagService.java
+++ b/src/main/java/com/example/place/domain/tag/service/TagService.java
@@ -1,5 +1,7 @@
 package com.example.place.domain.tag.service;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.example.place.common.exception.enums.ExceptionCode;
@@ -8,6 +10,7 @@ import com.example.place.domain.tag.dto.request.TagRequest;
 import com.example.place.domain.tag.dto.response.TagResponse;
 import com.example.place.domain.tag.entity.Tag;
 import com.example.place.domain.tag.repository.TagRepository;
+import com.example.place.domain.tag.util.TagUtil;
 import com.example.place.domain.user.entity.User;
 import com.example.place.domain.usertag.entity.UserTag;
 import com.example.place.domain.item.entity.Item;
@@ -61,7 +64,13 @@ public class TagService {
 
     // 유저 태그 저장 메서드
     public void saveTags(User user, Set<String> tagNames) {
-        for (String tagName: tagNames) {
+        Set<String> normalizedTags = new LinkedHashSet<>();
+
+        for (String tagName : tagNames) {
+            normalizedTags.add(TagUtil.normalizeTag(tagName));
+        }
+
+        for (String tagName : normalizedTags) {
             Tag tag = findOrCreateTag(tagName);
             user.addUserTag(UserTag.of(tag, user));
         }
@@ -69,7 +78,13 @@ public class TagService {
 
     // 아이템 태그 저장 메서드
     public void saveTags(Item item, Set<String> tagNames) {
-        for (String tagName: tagNames) {
+        Set<String> normalizedTags = new HashSet<>();
+
+        for (String tagName : tagNames) {
+            normalizedTags.add(TagUtil.normalizeTag(tagName));
+        }
+
+        for (String tagName : normalizedTags) {
             Tag tag = findOrCreateTag(tagName);
             item.addItemTag(ItemTag.of(tag, item));
         }

--- a/src/main/java/com/example/place/domain/tag/util/TagUtil.java
+++ b/src/main/java/com/example/place/domain/tag/util/TagUtil.java
@@ -1,0 +1,10 @@
+package com.example.place.domain.tag.util;
+
+public class TagUtil {
+
+	// 태그 정규화(공백 제거, 특수문자 제거)
+	public static String normalizeTag(String tag) {
+		return tag.toLowerCase()
+			.replaceAll("[^a-zA-Z0-9가-힣]", "");
+	}
+}

--- a/src/main/java/com/example/place/domain/user/dto/UserRegisterRequest.java
+++ b/src/main/java/com/example/place/domain/user/dto/UserRegisterRequest.java
@@ -1,6 +1,6 @@
 package com.example.place.domain.user.dto;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import jakarta.validation.constraints.Email;
@@ -30,7 +30,7 @@ public class UserRegisterRequest {
 	private final String imageUrl;
 
 	@Size(max = 5, message = "태그는 최대 5개까지 등록할 수 있습니다.")
-	private final Set<@Size(max = 70, message = "태그명은 70자를 초과할 수 없습니다.")String> tags = new HashSet<>();
+	private final Set<@Size(max = 70, message = "태그명은 70자를 초과할 수 없습니다.")String> tags = new LinkedHashSet<>();
 
 	public UserRegisterRequest(String name, String nickname, String email, String password, String imageUrl) {
 		this.name = name;

--- a/src/main/java/com/example/place/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/place/domain/user/dto/UserUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.example.place.domain.user.dto;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import jakarta.validation.constraints.Size;
@@ -14,7 +14,7 @@ public class UserUpdateRequest {
 	private final String nickname;
 	private final String imageUrl;
 	@Size(max = 5, message = "태그는 최대 5개까지 등록할 수 있습니다.")
-	private final Set<@Size(max = 70, message = "태그명은 70자를 초과할 수 없습니다.")String> tags = new HashSet<>();
+	private final Set<@Size(max = 70, message = "태그명은 70자를 초과할 수 없습니다.")String> tags = new LinkedHashSet<>();
 
 	public UserUpdateRequest(String name, String nickname, String imageUrl) {
 		this.name = name;


### PR DESCRIPTION
## 개요
태그 저장시 정규화(공백, 특수문자 제거)기능 추가

## 작업 사항
- [ ] Tag 도메인에 util 패키지 추가, TagUtil 클래스 생성
- [ ] 태그 정규화 유틸 메서드 추가
- [ ] 정규화 후에 중복이 되는 문제 해결을 위해 saveTags 메서드 로직 수정
- [ ] 순서 유지를 위해 HashSet -> LinkedHashSet으로 변경

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #192 
## 기능 확인
<img width="455" height="592" alt="image" src="https://github.com/user-attachments/assets/227ffa42-314b-40cf-80c5-55cf507ea642" />



---
