### PR TITLE
feat: 상품과 상품 댓글 soft delete로 수정

### DIFF
--- a/src/main/java/com/example/place/domain/item/entity/Item.java
+++ b/src/main/java/com/example/place/domain/item/entity/Item.java
@@ -6,7 +6,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import com.example.place.common.entity.BaseEntity;
+import com.example.place.common.entity.SoftDeleteEntity;
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
 import com.example.place.domain.Image.entity.Image;
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "items")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Item extends BaseEntity {
+public class Item extends SoftDeleteEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/example/place/domain/item/service/ItemDeleteService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemDeleteService.java
@@ -2,6 +2,7 @@ package com.example.place.domain.item.service;
 
 import org.springframework.stereotype.Service;
 
+import com.example.place.domain.itemcomment.service.ItemCommentService;
 import com.example.place.domain.order.service.OrderService;
 
 import org.springframework.transaction.annotation.Transactional;
@@ -14,10 +15,12 @@ public class ItemDeleteService {
 
 	private final OrderService orderService;
 	private final ItemService itemService;
+	private final ItemCommentService itemCommentService;
 
 	@Transactional
 	public void removeReferencesAndDeleteItem(Long itemId, Long userId) {
 		orderService.removeItemReferenceFromOrders(itemId);
-		itemService.deleteItem(itemId, userId);
+		itemService.softDeleteItem(itemId, userId);
+		itemCommentService.softDeleteAllItemComment(itemId);
 	}
 }

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -117,6 +117,18 @@ public class ItemService {
 	}
 
 	@Transactional
+	public void softDeleteItem(Long itemId, Long userId) {
+		Item item = findByIdOrElseThrow(itemId);
+
+		if (!findByIdOrElseThrow(itemId).getUser().getId().equals(userId)) {
+			throw new CustomException(ExceptionCode.FORBIDDEN_ITEM_DELETE);
+		}
+
+		item.delete();
+
+	}
+
+	@Transactional
 	public PageResponseDto<ItemResponse> searchItems(String keyword, List<String> tags, Long userId, Pageable pageable) {
 		List<Item> items = itemRepository.searchitems(keyword, userId, tags);
 

--- a/src/main/java/com/example/place/domain/itemcomment/controller/ItemCommentController.java
+++ b/src/main/java/com/example/place/domain/itemcomment/controller/ItemCommentController.java
@@ -101,7 +101,7 @@ public class ItemCommentController {
 		@PathVariable Long itemCommentId,
 		@AuthenticationPrincipal CustomPrincipal principal) {
 
-		itemCommentService.deleteItemComment(itemId, itemCommentId, principal);
+		itemCommentService.softDeleteItemComment(itemId, itemCommentId, principal);
 
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("댓글을 삭제하였습니다.", null));
 	}

--- a/src/main/java/com/example/place/domain/itemcomment/entity/ItemComment.java
+++ b/src/main/java/com/example/place/domain/itemcomment/entity/ItemComment.java
@@ -1,6 +1,7 @@
 package com.example.place.domain.itemcomment.entity;
 
 import com.example.place.common.entity.BaseEntity;
+import com.example.place.common.entity.SoftDeleteEntity;
 import com.example.place.domain.item.entity.Item;
 import com.example.place.domain.user.entity.User;
 
@@ -19,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "itemcomments")
-public class ItemComment extends BaseEntity {
+public class ItemComment extends SoftDeleteEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/place/domain/itemcomment/repository/ItemCommentRepository.java
+++ b/src/main/java/com/example/place/domain/itemcomment/repository/ItemCommentRepository.java
@@ -1,15 +1,18 @@
 package com.example.place.domain.itemcomment.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import com.example.place.domain.itemcomment.entity.ItemComment;
 
 public interface ItemCommentRepository extends JpaRepository<ItemComment, Long> {
 
 	@EntityGraph(attributePaths = {"user"})
-	Page<ItemComment> findByItemId(Long itemId, Pageable pageable);
+	Page<ItemComment> findPageByItemId(Long itemId, Pageable pageable);
+
+	List<ItemComment> findByItemId(Long itemId);
 }


### PR DESCRIPTION
## 개요
feat: 상품과 상품 댓글 soft delete로 수정

## 작업 사항
- 상품과 상품 댓글을 soft-delete 하는 메서드 생성
- 컨트롤러에서 삭제 요청시 해당 메서드를 사용하도록 수정
- 상품 soft-delete시 연관 상품 댓글들도 soft-delete되도록 수정

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #219
- 참고 자료: [링크]

---
