### PR TITLE
feat: 로그인 유저의 관심태그로 전체 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ dependencies {
 
 	implementation 'me.paulschwarz:spring-dotenv:3.0.0'
 
+	// Query DSL
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/place/common/config/JpaConfig.java
+++ b/src/main/java/com/example/place/common/config/JpaConfig.java
@@ -1,10 +1,24 @@
 package com.example.place.common.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 
 @Configuration
 @EnableJpaAuditing
 public class JpaConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
 }
 

--- a/src/main/java/com/example/place/domain/item/controller/ItemController.java
+++ b/src/main/java/com/example/place/domain/item/controller/ItemController.java
@@ -5,6 +5,7 @@ import com.example.place.common.dto.PageResponseDto;
 import com.example.place.common.security.jwt.CustomPrincipal;
 import com.example.place.domain.item.dto.request.ItemRequest;
 import com.example.place.domain.item.dto.response.ItemResponse;
+import com.example.place.domain.item.dto.response.ItemSummaryResponse;
 import com.example.place.domain.item.service.ItemDeleteService;
 import com.example.place.domain.item.service.ItemService;
 import org.springframework.data.domain.Pageable;
@@ -73,6 +74,15 @@ public class ItemController {
             @PageableDefault Pageable pageable
             ) {
         PageResponseDto<ItemResponse> result = itemService.searchItems(keyword, tags, userId, itemDescription, pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("상품 조회가 완료되었습니다", result));
+    }
+
+    @GetMapping("/search/interest")
+    public ResponseEntity<ApiResponseDto<PageResponseDto<ItemSummaryResponse>>> searchItemWithUserTag(
+        @PageableDefault Pageable pageable,
+        @AuthenticationPrincipal CustomPrincipal principal
+    ) {
+        PageResponseDto<ItemSummaryResponse> result = itemService.getAllItemsWIthUserTag(principal, pageable);
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("상품 조회가 완료되었습니다", result));
     }
 

--- a/src/main/java/com/example/place/domain/item/controller/ItemController.java
+++ b/src/main/java/com/example/place/domain/item/controller/ItemController.java
@@ -29,10 +29,10 @@ public class ItemController {
     private final ItemDeleteService itemDeleteService;
 
     /**
-     * 상품 생성 기존 Tag가 있다면 사용 없다면 생성해서 상품등록
+     * 상품 생성
      *
      * @param request
-     * @param
+     * @param principal
      * @return
      */
     @PostMapping
@@ -57,11 +57,12 @@ public class ItemController {
     }
 
     /**
-     * 원하는 값으로 조회
+     * 상품 서치
      *
      * @param keyword
      * @param tags
      * @param userId
+     * @param itemDescription
      * @param pageable
      * @return
      */
@@ -77,19 +78,28 @@ public class ItemController {
         return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("상품 조회가 완료되었습니다", result));
     }
 
+    /**
+     * 로그인한 유저의 관심태그가 포함된 상품 전체 조회
+     *
+     * @param pageable
+     * @param principal
+     * @return
+     */
     @GetMapping("/search/interest")
     public ResponseEntity<ApiResponseDto<PageResponseDto<ItemSummaryResponse>>> searchItemWithUserTag(
         @PageableDefault Pageable pageable,
         @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        PageResponseDto<ItemSummaryResponse> result = itemService.getAllItemsWIthUserTag(principal, pageable);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("상품 조회가 완료되었습니다", result));
+        PageResponseDto<ItemSummaryResponse> response = itemService.getAllItemsWIthUserTag(principal, pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("상품 조회가 완료되었습니다", response));
     }
 
     /**
-     * 상품 단건 수정
+     * 상품 수정
      *
+     * @param itemId
      * @param request
+     * @param principal
      * @return
      */
     @PatchMapping("/{itemId}")

--- a/src/main/java/com/example/place/domain/item/dto/response/ItemSummaryResponse.java
+++ b/src/main/java/com/example/place/domain/item/dto/response/ItemSummaryResponse.java
@@ -3,6 +3,7 @@ package com.example.place.domain.item.dto.response;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.item.entity.Item;
 
 import lombok.Getter;
@@ -13,13 +14,16 @@ public class ItemSummaryResponse {
 	private String itemName;
 	private Double price;
 	private Long count;
+	private String mainImageUrl;
 	private List<String> tags;
 
-	private ItemSummaryResponse(Long id, String itemName, Double price, Long count, List<String> tags) {
+	private ItemSummaryResponse(Long id, String itemName, Double price, Long count, String mainImageUrl,
+		List<String> tags) {
 		this.id = id;
 		this.itemName = itemName;
 		this.price = price;
 		this.count = count;
+		this.mainImageUrl = mainImageUrl;
 		this.tags = tags;
 	}
 
@@ -29,6 +33,11 @@ public class ItemSummaryResponse {
 			item.getItemName(),
 			item.getPrice(),
 			item.getCount(),
+			item.getImages().stream()
+				.filter(Image::isMain)
+				.findFirst()
+				.map(Image::getImageUrl)
+				.orElse(null),
 			item.getItemTags().stream()
 				.map(itemTag -> itemTag.getTag().getTagName())
 				.collect(Collectors.toList())

--- a/src/main/java/com/example/place/domain/item/dto/response/ItemSummaryResponse.java
+++ b/src/main/java/com/example/place/domain/item/dto/response/ItemSummaryResponse.java
@@ -1,0 +1,37 @@
+package com.example.place.domain.item.dto.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.example.place.domain.item.entity.Item;
+
+import lombok.Getter;
+
+@Getter
+public class ItemSummaryResponse {
+	private Long id;
+	private String itemName;
+	private Double price;
+	private Long count;
+	private List<String> tags;
+
+	private ItemSummaryResponse(Long id, String itemName, Double price, Long count, List<String> tags) {
+		this.id = id;
+		this.itemName = itemName;
+		this.price = price;
+		this.count = count;
+		this.tags = tags;
+	}
+
+	public static ItemSummaryResponse from(Item item) {
+		return new ItemSummaryResponse(
+			item.getId(),
+			item.getItemName(),
+			item.getPrice(),
+			item.getCount(),
+			item.getItemTags().stream()
+				.map(itemTag -> itemTag.getTag().getTagName())
+				.collect(Collectors.toList())
+		);
+	}
+}

--- a/src/main/java/com/example/place/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/place/domain/item/repository/ItemRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ItemRepository extends JpaRepository<Item, Long> {
+public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
 
 
     @Query("""

--- a/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.place.domain.item.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.example.place.domain.item.entity.Item;
+import com.example.place.domain.user.entity.User;
+
+public interface ItemRepositoryCustom {
+	Page<Item> findByUserTag(User user, Pageable pageable);
+}

--- a/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustomImpl.java
@@ -1,0 +1,80 @@
+package com.example.place.domain.item.repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import com.example.place.domain.item.dto.response.ItemSummaryResponse;
+import com.example.place.domain.item.entity.Item;
+import com.example.place.domain.item.entity.QItem;
+import com.example.place.domain.itemtag.entity.QItemTag;
+import com.example.place.domain.tag.entity.QTag;
+import com.example.place.domain.user.entity.User;
+import com.example.place.domain.usertag.entity.QUserTag;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<Item> findByUserTag(User user, Pageable pageable) {
+		QItem item = QItem.item;
+		QItemTag itemTag = QItemTag.itemTag;
+		QUserTag userTag = QUserTag.userTag;
+		QTag tag = QTag.tag;
+
+		// 페이지의 id 조회
+		JPQLQuery<Long> interestedTagIds = JPAExpressions
+			.select(userTag.tag.id)
+			.from(userTag)
+			.where(userTag.user.eq(user));
+
+		List<Long> itemIds = queryFactory
+			.select(item.id)
+			.from(item)
+			.join(item.itemTags, itemTag)
+			.join(itemTag.tag, tag)
+			.where(
+				item.isDeleted.isFalse(),
+				tag.id.in(interestedTagIds))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		if (itemIds.isEmpty()) {
+			return new PageImpl<>(Collections.emptyList(), pageable, 0);
+		}
+
+		// 페이지의 상품들 정보 조회
+		List<Item> items = queryFactory
+			.selectFrom(item)
+			.distinct()
+			.join(item.itemTags, itemTag).fetchJoin()
+			.join(itemTag.tag, tag).fetchJoin()
+			.where(item.id.in(itemIds))
+			.fetch();
+
+		// 페이징 처리를 위한 전체 열 카운트
+		long total = Optional.ofNullable(
+			queryFactory
+				.select(item.countDistinct()) // fetchJoin 없이 count 하기위해 distinct
+				.from(item)
+				.join(item.itemTags, itemTag)
+				.join(itemTag.tag, tag)
+				.where(item.isDeleted.isFalse())
+				.fetchOne()
+		).orElse(0L);
+
+		return new PageImpl<>(items, pageable, total);
+	}
+}

--- a/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustomImpl.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import com.example.place.domain.item.dto.response.ItemSummaryResponse;
+import com.example.place.domain.Image.entity.QImage;
 import com.example.place.domain.item.entity.Item;
 import com.example.place.domain.item.entity.QItem;
 import com.example.place.domain.itemtag.entity.QItemTag;
@@ -61,6 +61,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
 			.distinct()
 			.join(item.itemTags, itemTag).fetchJoin()
 			.join(itemTag.tag, tag).fetchJoin()
+			.join(item.images).fetchJoin()
 			.where(item.id.in(itemIds))
 			.fetch();
 

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -88,7 +88,7 @@ public class ItemService {
 		return ItemResponse.from(item);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public PageResponseDto<ItemSummaryResponse> getAllItemsWIthUserTag(CustomPrincipal principal, Pageable pageable) {
 		User user = userService.findByIdOrElseThrow(principal.getId());
 

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -1,13 +1,16 @@
 package com.example.place.domain.item.service;
 
 import com.example.place.common.dto.PageResponseDto;
+import com.example.place.common.security.jwt.CustomPrincipal;
 import com.example.place.domain.Image.service.ImageService;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.item.dto.request.ItemRequest;
 import com.example.place.domain.item.dto.response.ItemResponse;
+import com.example.place.domain.item.dto.response.ItemSummaryResponse;
 import com.example.place.domain.item.entity.Item;
 import com.example.place.domain.item.repository.ItemRepository;
 
+import com.example.place.domain.itemcomment.dto.response.ItemCommentResponse;
 import com.example.place.domain.tag.service.TagService;
 import com.example.place.domain.user.entity.User;
 import com.example.place.domain.user.service.UserService;
@@ -147,6 +150,17 @@ public class ItemService {
 		return new PageResponseDto<>(page);
 	}
 
+	@Transactional
+	public PageResponseDto<ItemSummaryResponse> getAllItemsWIthUserTag(CustomPrincipal principal, Pageable pageable) {
+		User user = userService.findByIdOrElseThrow(principal.getId());
+
+		Page<Item> pagedItems = itemRepository.findByUserTag(user, pageable);
+
+		Page<ItemSummaryResponse> response = pagedItems.map(ItemSummaryResponse::from);
+
+		return new PageResponseDto<>(response);
+	}
+
 	public Item findByIdOrElseThrow(Long id) {
 		Item item = itemRepository.findById(id)
 				.orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_ITEM));
@@ -168,6 +182,7 @@ public class ItemService {
 			.map(Image::getImageUrl)
 			.orElse(null);
 	}
+
 	private List<LocalDateTime> setSalesTime(ItemRequest request) {
 
 		LocalDateTime salesStartAt = request.getSalesStartAt() != null

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: Mania-Place
 
   datasource:
-    url: jdbc:mysql://localhost:3306/mania_place
+    url: jdbc:mysql://localhost:3307/mania_place
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}


### PR DESCRIPTION
## 개요
로그인한 유저의 관심태그가 포함된 상품에 한하여 전체 조회하는 기능입니다.

## 작업 사항
- QueryDSL 도입
- 유저 관심 태그로 전체조회
- 전체 조회 응답값은 요약 응답값을 사용
- 요약 응답값 : itemId(프론트에서 다음 단건 조회를 위해 사용), itemName, price, count(프론트에서 판매완료 여부를 나타내기 위해 사용), mainImageUrl(미리보기를 위해 사용), tags

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #242 
- 참고 자료: [링크]

---
