### PR TITLE
Issue/263 feature 5w1h

### DIFF
--- a/src/main/java/com/example/place/common/aop/LoggingAspect.java
+++ b/src/main/java/com/example/place/common/aop/LoggingAspect.java
@@ -46,7 +46,7 @@ public class LoggingAspect {
 		String methodName = joinPoint.getSignature().toShortString();
 
 		// 입력 파라미터 JSON 직렬화 + 마스킹
-		String paramsJson = serializeAndMaskResponse(joinPoint.getArgs());
+		String paramsJson = serializeAndMask(joinPoint.getArgs());
 
 		try {
 			// 실제 대상 메서드 실행
@@ -57,7 +57,7 @@ public class LoggingAspect {
 			RequestInfo requestInfo = captureRequestInfo();
 
 			// 결과 객체를 JSON으로 직렬화하고 민감 데이터 마스킹 처리
-			String responseBody = serializeAndMaskResponse(result);
+			String responseBody = serializeAndMask(result);
 
 			// 성공 로그 기록 (메서드명과 파라미터 포함)
 			logSuccess(requestInfo, methodName, responseBody, duration, paramsJson);
@@ -114,17 +114,17 @@ public class LoggingAspect {
 	}
 
 	// 응답 객체를 JSON 문자열로 직렬화하고 민감정보를 마스킹 처리하는 메서드
-	private String serializeAndMaskResponse(Object response) {
-		if (response == null) {
+	private String serializeAndMask(Object data) {
+		if (data == null) {
 			return "null";
 		}
 
 		try {
-			String json = objectMapper.writeValueAsString(response);
+			String json = objectMapper.writeValueAsString(data);
 			return maskSensitiveData(json);
 		} catch (Exception e) {
-			log.warn("Response 직렬화 실패: {}", e.getMessage());
-			return "Response 직렬화 실패";
+			log.warn("직렬화 실패: {}", e.getMessage());
+			return "직렬화 실패";
 		}
 	}
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,24 +4,24 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/app.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <!-- 로그 저장 기간, 저장 용량 제한 -->
-            <maxFileSize>10KB</maxFileSize>
+            <maxFileSize>1MB</maxFileSize>
             <maxHistory>30</maxHistory>
-            <totalSizeCap>50KB</totalSizeCap>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta(%-4relative) %highlight(%-5level) [%thread] %cyan(%logger{35}) - %msg%n</pattern>
         </encoder>
     </appender>
 
     <!-- 콘솔 출력용 Appender 추가 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %magenta(%-4relative) %highlight(%-5level) [%thread] %cyan(%logger{35}) - %msg%n</pattern>
         </encoder>
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="CONSOLE" />
-        <appender-ref ref="ROLLINGFILE" />
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="ROLLINGFILE"/>
     </root>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -16,8 +16,7 @@
     <!-- 콘솔 출력용 Appender 추가 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern><pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
-            </pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
개요
직렬화된 로그 출력 시 Params: 및 Response: 프리픽스가 중복되는 문제를 수정했습니다.

작업 사항
 toMaskedJson() 메서드 내에서 prefix 제거

 로그 출력부에서만 Params: / Response: 접두어 붙이도록 변경

 관련 경고 로그 메시지 개선

로그 수집 내용 추가 및 변경

누가 (Who)
사용자 정보: 인증된 사용자는 email, 미인증은 anonymous

실행 메서드명: 클래스.메서드(..) 형태로 수집

언제 (When)
시작 시각과 종료 시각 측정 → 실행 시간(ms) 계산

로그 저장 시각은 로그 포맷 인코더에서 표시

어디서 (Where)
HTTP 메서드(GET/POST)

요청 URI

실행된 메서드 위치 (시그니처)

무엇을 (What)
입력 파라미터와 응답 데이터

예외 메시지

민감 정보는 정규식으로 마스킹 처리

어떻게 (How)
로그는 한 줄 요약 형태로 기록됨

[POST] /api/login - AuthService.login(..) - anonymous (96 ms) - ERROR: 존재하지 않는 회원입니다. | Params: [{"email":"","password":""}]

왜 (Why)
성능 추적 (duration)

디버깅 용이

보안 감사 (마스킹 및 사용자 추적)

사용자 행동 분석 (누가 어떤 URI 호출했는지)

xml rollingPolicy 정책 변경 및 encoder 로그색 pattern 커스터마이징

리뷰 요청 포인트

기타 사항
관련 이슈: 없음

참고 자료: 없음
---
