### PR TITLE
feat: 사용자 관심 태그 기반 상품 조회 결과가 없다면 전체 조회

### DIFF
--- a/src/main/java/com/example/place/domain/item/controller/ItemController.java
+++ b/src/main/java/com/example/place/domain/item/controller/ItemController.java
@@ -70,10 +70,10 @@ public class ItemController {
      */
     @GetMapping("/search")
     public ResponseEntity<ApiResponseDto<PageResponseDto<ItemSummaryResponse>>> searchItem(
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) List<String> tags,
-            @RequestParam(required = false) Long userId,
-            @PageableDefault Pageable pageable
+        @RequestParam(required = false) String keyword,
+        @RequestParam(required = false) List<String> tags,
+        @RequestParam(required = false) Long userId,
+        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
             ) {
         if (tags != null && tags.size() > 10) {
             throw new CustomException(ExceptionCode.TOO_MANY_TAGS);
@@ -91,7 +91,7 @@ public class ItemController {
      */
     @GetMapping("/search/interest")
     public ResponseEntity<ApiResponseDto<PageResponseDto<ItemSummaryResponse>>> searchItemWithUserTag(
-        @PageableDefault Pageable pageable,
+        @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
         @AuthenticationPrincipal CustomPrincipal principal
     ) {
         PageResponseDto<ItemSummaryResponse> response = itemService.getAllItemsWIthUserTag(principal, pageable);

--- a/src/main/java/com/example/place/domain/item/controller/ItemController.java
+++ b/src/main/java/com/example/place/domain/item/controller/ItemController.java
@@ -5,6 +5,7 @@ import com.example.place.common.dto.PageResponseDto;
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
 import com.example.place.common.security.jwt.CustomPrincipal;
+import com.example.place.domain.item.dto.PagedItemSummaryResponse;
 import com.example.place.domain.item.dto.request.ItemRequest;
 import com.example.place.domain.item.dto.response.ItemResponse;
 import com.example.place.domain.item.dto.response.ItemSummaryResponse;
@@ -94,8 +95,15 @@ public class ItemController {
         @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
         @AuthenticationPrincipal CustomPrincipal principal
     ) {
-        PageResponseDto<ItemSummaryResponse> response = itemService.getAllItemsWIthUserTag(principal, pageable);
-        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("상품 조회가 완료되었습니다", response));
+        PagedItemSummaryResponse result = itemService.getAllItemsWIthUserTag(principal, pageable);
+        PageResponseDto<ItemSummaryResponse> response = result.getResponse();
+        String message;
+        if (result.isFindByUserTag()) {
+            message = "관심 태그에 기반한 상품 조회가 완료되었습니다.";
+        } else {
+            message = "관심 태그에 기반한 상품이 없습니다. 전체 조회 결과입니다.";
+        }
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of(message, response));
     }
 
     /**

--- a/src/main/java/com/example/place/domain/item/dto/PagedItemSummaryResponse.java
+++ b/src/main/java/com/example/place/domain/item/dto/PagedItemSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.example.place.domain.item.dto;
+
+import com.example.place.common.dto.PageResponseDto;
+import com.example.place.domain.item.dto.response.ItemSummaryResponse;
+
+import lombok.Getter;
+
+@Getter
+public class PagedItemSummaryResponse {
+	private PageResponseDto<ItemSummaryResponse> response;
+	private boolean isFindByUserTag;
+
+	private PagedItemSummaryResponse(PageResponseDto<ItemSummaryResponse> response, boolean isFindByUserTag) {
+		this.response = response;
+		this.isFindByUserTag = isFindByUserTag;
+	}
+
+	public static PagedItemSummaryResponse of(PageResponseDto<ItemSummaryResponse> response, boolean isFindByUserTag) {
+		return new PagedItemSummaryResponse(response, isFindByUserTag);
+	}
+}

--- a/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustom.java
@@ -9,7 +9,7 @@ import com.example.place.domain.item.entity.Item;
 import com.example.place.domain.user.entity.User;
 
 public interface ItemRepositoryCustom {
+	Page<Item> findAllCustom(Pageable pageable);
 	Page<Item> findByUserTag(User user, Pageable pageable);
-
 	Page<Item> search(String keyword, List<String> tags, Long userId, Pageable pageable);
 }

--- a/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/example/place/domain/item/repository/ItemRepositoryCustomImpl.java
@@ -37,6 +37,12 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
+	public Page<Item> findAllCustom(Pageable pageable) {
+		BooleanExpression whereCondition = null;
+		return createPagedItem(whereCondition, pageable);
+	}
+
+	@Override
 	public Page<Item> findByUserTag(User user, Pageable pageable) {
 
 		// 유저의 관심 태그를 조회하는 서브쿼리


### PR DESCRIPTION
## 개요
사용자 관심 태그 기반 상품 조회 결과가 없다면 전체 조회

## 작업 사항
- 사용자 관심 태그 기반 상품 조회 결과가 없다면 전체 조회 결과를 반환합니다.
- 관심 태그로 조회되었을 때와 전체 조회 된 경우 다른 메시지를 보입니다.
- 상품 전체 조회의 결과들을 최신순으로 정렬되도록 변경하였습니다. (최신순/오래된 순에서만 선택 가능)

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #262
- 참고 자료: [링크]

---
