### PR TITLE
feature(newsfeed): 단건 조회, 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
@@ -11,12 +11,11 @@ import com.example.place.domain.Image.entity.Image;
 public interface ImageRepository extends JpaRepository<Image, Long> {
 	List<Image> findByItemId(Long itemId);
 
-	List<Image> findByNewsfeedId(Long newsfeedId);
-
 	@Query("SELECT i FROM Image i WHERE i.item.id IN :itemIds")
 	List<Image> findByItemIds(@Param("itemIds") List<Long> itemIds);
 
-	@Query("SELECT i FROM Image i WHERE i.newsfeed.id IN :newsfeedIds")
-	List<Image> findByNewsfeedIds(@Param("newsfeedIds") List<Long> newsfeedIds);
+	//뉴스피드 전체 조회 이미지 리스트
+	@Query("SELECT i FROM Image i WHERE i.newsfeed.id IN :newsfeedIds AND i.isMain = true")
+	List<Image> findMainImagesByNewsfeedIds(@Param("newsfeedIds") List<Long> newsfeedIds);
 }
 

--- a/src/main/java/com/example/place/domain/newsfeed/controller/NewsfeedController.java
+++ b/src/main/java/com/example/place/domain/newsfeed/controller/NewsfeedController.java
@@ -1,11 +1,15 @@
 package com.example.place.domain.newsfeed.controller;
 
 import com.example.place.common.dto.ApiResponseDto;
+import com.example.place.common.dto.PageResponseDto;
 import com.example.place.common.security.jwt.CustomPrincipal;
 import com.example.place.domain.newsfeed.dto.request.NewsfeedRequest;
+import com.example.place.domain.newsfeed.dto.response.NewsfeedListResponse;
 import com.example.place.domain.newsfeed.dto.response.NewsfeedResponse;
 import com.example.place.domain.newsfeed.service.NewsfeedService;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +25,7 @@ public class NewsfeedController {
 
 	private final NewsfeedService newsfeedService;
 
+	//새소식 생성
 	@PostMapping
 	public ResponseEntity<ApiResponseDto<NewsfeedResponse>> createNewsfeed(
 		@Valid @RequestBody NewsfeedRequest request,
@@ -28,6 +33,24 @@ public class NewsfeedController {
 	) {
 		NewsfeedResponse newsfeed = newsfeedService.createNewsfeed(principal.getId(), request);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 등록이 완료되었습니다.", newsfeed));
+	}
+
+	//단건 조회
+	@GetMapping("/{newsfeedId}")
+	public ResponseEntity<ApiResponseDto<NewsfeedResponse>> getNewsfeed(@PathVariable Long newsfeedId) {
+		NewsfeedResponse newsfeed = newsfeedService.getNewsfeed(newsfeedId);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 조회가 완료되었습니다.", newsfeed));
+	}
+
+	//전체 조회
+	@GetMapping
+	public ResponseEntity<ApiResponseDto<PageResponseDto<NewsfeedListResponse>>> getAllNewsfeeds(
+		@PageableDefault Pageable pageable
+	) {
+		//리스트로 가져오기
+		PageResponseDto<NewsfeedListResponse> response =
+			newsfeedService.getAllNewsfeeds(pageable);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 전체 조회가 완료되었습니다", response));
 	}
 
 }

--- a/src/main/java/com/example/place/domain/newsfeed/dto/response/NewsfeedListResponse.java
+++ b/src/main/java/com/example/place/domain/newsfeed/dto/response/NewsfeedListResponse.java
@@ -1,0 +1,32 @@
+package com.example.place.domain.newsfeed.dto.response;
+
+import com.example.place.domain.newsfeed.entity.Newsfeed;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsfeedListResponse {
+	private Long id;
+	private String title;
+	private String content;
+	private String mainImageUrl;
+
+	private NewsfeedListResponse(Long id, String title, String content, String mainImageUrl) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.mainImageUrl = mainImageUrl;
+	}
+
+	public static NewsfeedListResponse of(Newsfeed newsfeed, String mainImageUrl) {
+		return new NewsfeedListResponse(
+			newsfeed.getId(),
+			newsfeed.getTitle(),
+			newsfeed.getContent(),
+			mainImageUrl
+		);
+	}
+}

--- a/src/main/java/com/example/place/domain/newsfeed/repository/NewsfeedRepository.java
+++ b/src/main/java/com/example/place/domain/newsfeed/repository/NewsfeedRepository.java
@@ -1,10 +1,15 @@
 package com.example.place.domain.newsfeed.repository;
 
 import com.example.place.domain.newsfeed.entity.Newsfeed;
+import com.example.place.domain.user.entity.User;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NewsfeedRepository extends JpaRepository<Newsfeed, Long> {
+
+	Page<Newsfeed> findByIsDeletedFalse(Pageable pageable);
 }

--- a/src/main/java/com/example/place/domain/newsfeed/service/NewsfeedService.java
+++ b/src/main/java/com/example/place/domain/newsfeed/service/NewsfeedService.java
@@ -1,14 +1,25 @@
 package com.example.place.domain.newsfeed.service;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.example.place.common.annotation.Loggable;
+import com.example.place.common.dto.PageResponseDto;
+import com.example.place.domain.Image.repository.ImageRepository;
 import com.example.place.domain.Image.service.ImageService;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.newsfeed.dto.request.NewsfeedRequest;
+import com.example.place.domain.newsfeed.dto.response.NewsfeedListResponse;
 import com.example.place.domain.newsfeed.dto.response.NewsfeedResponse;
 import com.example.place.domain.newsfeed.entity.Newsfeed;
 import com.example.place.domain.newsfeed.repository.NewsfeedRepository;
 import com.example.place.domain.user.entity.User;
 import com.example.place.domain.user.service.UserService;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import com.example.place.common.exception.enums.ExceptionCode;
@@ -23,9 +34,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class NewsfeedService {
 
 	private final NewsfeedRepository newsfeedRepository;
+	private final ImageRepository imageRepository;
 	private final UserService userService;
 	private final ImageService imageService;
 
+	@Loggable
 	@Transactional
 	public NewsfeedResponse createNewsfeed(Long userId, NewsfeedRequest request) {
 		User user = userService.findByIdOrElseThrow(userId);
@@ -42,15 +55,63 @@ public class NewsfeedService {
 		return NewsfeedResponse.from(savedNewsfeed);
 	}
 
-	public String getMainImageUrl(Long newsfeedId) {
-		Newsfeed newsfeed = newsfeedRepository.findById(newsfeedId)
+	@Loggable
+	@Transactional(readOnly = true)
+	public NewsfeedResponse getNewsfeed(Long newsfeedId) {
+		Newsfeed newsfeed = findByIdOrElseThrow(newsfeedId);
+		return NewsfeedResponse.from(newsfeed);
+	}
+
+	@Loggable
+	@Transactional(readOnly = true)
+	public PageResponseDto<NewsfeedListResponse> getAllNewsfeeds(Pageable pageable) {
+
+		// 새소식 전체 조회(소프트딜리트 빼고)
+		Page<Newsfeed> pagedNewsfeeds = newsfeedRepository.findByIsDeletedFalse(pageable);
+
+		// 페이지에 들어갈 새소식 ID 추출
+		List<Long> newsfeedIds = pagedNewsfeeds.getContent().stream()
+			.map(Newsfeed::getId)
+			.collect(Collectors.toList());
+
+		// 페이지에 들어갈 대표 이미지 일괄 조회
+		Map<Long, String> mainImageMap = getMainImageMap(newsfeedIds);
+
+		// NewsfeedListResponse 에 적용
+		Page<NewsfeedListResponse> response = pagedNewsfeeds.map(newsfeed ->
+			NewsfeedListResponse.of(newsfeed, mainImageMap.get(newsfeed.getId()))
+		);
+
+		return new PageResponseDto<>(response);
+	}
+
+	public Newsfeed findByIdOrElseThrow(Long id) {
+		Newsfeed newsfeed = newsfeedRepository.findById(id)
 			.orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_NEWSFEED));
 
-		return newsfeed.getImages().stream()
-			.filter(Image::isMain)
-			.findFirst()
-			.map(Image::getImageUrl)
-			.orElse(null);
+		if (newsfeed.isDeleted()) {
+			throw new CustomException(ExceptionCode.NOT_FOUND_NEWSFEED);
+		}
+
+		return newsfeed;
+	}
+
+	// 대표 이미지 조회
+	private Map<Long, String> getMainImageMap(List<Long> newsfeedIds) {
+		//ID가 비었으면 바로 반환
+		if (newsfeedIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		//대표 이미지만 조회
+		List<Image> mainImages = imageRepository.findMainImagesByNewsfeedIds(newsfeedIds);
+
+		//조회된 이미지 리스트를맵으로 변환
+		return mainImages.stream()
+			.collect(Collectors.toMap(
+				image -> image.getNewsfeed().getId(),
+				Image::getImageUrl
+			));
 	}
 }
 


### PR DESCRIPTION
## 개요
새소식 단건 조회, 전체 조회 기능 구현

## 작업 사항
-단건 조회(GET /newsfeeds/{id}) api 구현
-전체 조회(GET /newsfeeds) api 구현
-전체 조회 시 대표 이미지를 포함해 응답 반환 (리스트 내부에서 맵으로 변환 처리)
