### PR TITLE
Issue/268 feature newsfeed update/delete

### DIFF
--- a/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/example/place/common/exception/enums/ExceptionCode.java
@@ -30,6 +30,8 @@ public enum ExceptionCode {
 	FORBIDDEN_ITEM_DELETE(HttpStatus.FORBIDDEN, "본인 외에 상품은 삭제할 수 없습니다."),
 	FORBIDDEN_POST_ACCESS(HttpStatus.FORBIDDEN, "본인 외의 게시글은 수정할 수 없습니다."),
 	FORBIDDEN_POST_DELETE(HttpStatus.FORBIDDEN, "본인 외의 게시글은 삭제할 수 없습니다."),
+	FORBIDDEN_NEWSFEED_ACCESS(HttpStatus.FORBIDDEN, "본인 외의 게시글은 수정할 수 없습니다."),
+	FORBIDDEN_NEWSFEED_DELETE(HttpStatus.FORBIDDEN, "본인 외의 게시글은 삭제할 수 없습니다."),
 	FORBIDDEN_ORDER_ACCESS(HttpStatus.FORBIDDEN, "해당 주문은 본인의 주문이 아닙니다."),
 	ORDER_CANCEL_ACCESS_DENIED(HttpStatus.FORBIDDEN, "주문을 취소할 권한이 없습니다."),
 	ITEM_HAS_ACTIVE_ORDERS(HttpStatus.FORBIDDEN, "아직 진행 중인 주문이 있어 취소할 수 없습니다."),
@@ -56,7 +58,7 @@ public enum ExceptionCode {
 	EXISTS_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
 	EXISTS_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
 	BLACKLISTED_TOKEN(HttpStatus.CONFLICT, "다시 로그인 해주세요."),
-	DUPLICATED_TAG_NAME(HttpStatus.CONFLICT,"이미 존재하는 태그명입니다."),
+	DUPLICATED_TAG_NAME(HttpStatus.CONFLICT, "이미 존재하는 태그명입니다."),
 
 	// 동시성 제어 관련 예외
 	STOCK_LOCK_FAILED(HttpStatus.CONFLICT, "재고 처리 중입니다. 잠시 후 다시 시도해주세요."),

--- a/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
+++ b/src/main/java/com/example/place/domain/Image/repository/ImageRepository.java
@@ -14,6 +14,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 	@Query("SELECT i FROM Image i WHERE i.item.id IN :itemIds")
 	List<Image> findByItemIds(@Param("itemIds") List<Long> itemIds);
 
+	List<Image> findByNewsfeedId(Long newsfeedId);
+
 	//뉴스피드 전체 조회 이미지 리스트
 	@Query("SELECT i FROM Image i WHERE i.newsfeed.id IN :newsfeedIds AND i.isMain = true")
 	List<Image> findMainImagesByNewsfeedIds(@Param("newsfeedIds") List<Long> newsfeedIds);

--- a/src/main/java/com/example/place/domain/Image/service/ImageService.java
+++ b/src/main/java/com/example/place/domain/Image/service/ImageService.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
-import com.example.place.common.annotation.Loggable;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.Image.repository.ImageRepository;
 import com.example.place.domain.item.entity.Item;
@@ -58,13 +57,30 @@ public class ImageService {
 	}
 
 	// 이미지 수정
+	// Item 이미지 수정
 	@Transactional
 	public void updateImages(Item item, List<String> newImageUrls, int mainIndex) {
+		updateImagesCommon(item.getId(), null, item, null, newImageUrls, mainIndex);
+	}
+
+	// Newsfeed 이미지 수정
+	@Transactional
+	public void updateImages(Newsfeed newsfeed, List<String> newImageUrls, Integer mainIndex) {
+		int validMainIndex = (mainIndex != null) ? mainIndex : 0;
+		updateImagesCommon(null, newsfeed.getId(), null, newsfeed, newImageUrls, validMainIndex);
+	}
+
+	@Transactional
+	public void updateImagesCommon(Long itemId, Long newsfeedId, Item item, Newsfeed newsfeed,
+		List<String> newImageUrls, int mainIndex) {
 		// 새롭게 전달받은 이미지
 		Set<String> newImageSet = new HashSet<>(newImageUrls);
 
 		// 현재 저장되어 있는 이미지
-		List<Image> existingImages = imageRepository.findByItemId(item.getId());
+		List<Image> existingImages = (itemId != null)
+			? imageRepository.findByItemId(itemId)
+			: imageRepository.findByNewsfeedId(newsfeedId);
+
 		Set<String> existingImageSet = existingImages.stream()
 			.map(Image::getImageUrl)
 			.collect(Collectors.toSet());
@@ -107,12 +123,12 @@ public class ImageService {
 		imageRepository.deleteAll(images);
 	}
 
-	// //특정 NewsfeedId와 연관된 이미지를 일괄로 삭제
-	// @Transactional
-	// public void deleteImageByNewsfeedId(Long newsfeedId) {
-	// 	List<Image> images = imageRepository.findByNewsfeedId(newsfeedId);
-	// 	imageRepository.deleteAll(images);
-	// }
+	//특정 NewsfeedId와 연관된 이미지를 일괄로 삭제
+	@Transactional
+	public void deleteImageByNewsfeedId(Long newsfeedId) {
+		List<Image> images = imageRepository.findByNewsfeedId(newsfeedId);
+		imageRepository.deleteAll(images);
+	}
 
 	// 대표 이미지 인덱스 검증
 	private int validMainIndex(int listSize, int mainIndex) {

--- a/src/main/java/com/example/place/domain/Image/service/ImageService.java
+++ b/src/main/java/com/example/place/domain/Image/service/ImageService.java
@@ -100,16 +100,21 @@ public class ImageService {
 		Set<String> toSave = new HashSet<>(newImageSet);
 		toSave.removeAll(existingImageSet);
 
-		// 추가 처리
+		// 추가 처리(+Item/Newsfeed 구분해서)
 		for (String imageUrl : toSave) {
-			Image image = Image.of(item, imageUrl, false);  // 임시로 대표 이미지 false로 세팅
+			Image image = (item != null)
+				? Image.of(item, imageUrl, false)
+				: Image.of(newsfeed, imageUrl, false);  // 임시로 대표 이미지 false로 세팅
 			imageRepository.save(image);
 		}
 
 		// 대표 이미지 재설정
 		int validatedMainIndex = validMainIndex(newImageUrls.size(), mainIndex);
 		String mainImageUrl = newImageUrls.get(validatedMainIndex);
-		List<Image> images = imageRepository.findByItemId(item.getId());
+		// Item/Newsfeed 구분해서 조회
+		List<Image> images = (itemId != null)
+			? imageRepository.findByItemId(itemId)
+			: imageRepository.findByNewsfeedId(newsfeedId);
 		for (Image image : images) {
 			image.updateIsMain(image.getImageUrl().equals(mainImageUrl));
 		}

--- a/src/main/java/com/example/place/domain/newsfeed/controller/NewsfeedController.java
+++ b/src/main/java/com/example/place/domain/newsfeed/controller/NewsfeedController.java
@@ -53,4 +53,24 @@ public class NewsfeedController {
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 전체 조회가 완료되었습니다", response));
 	}
 
+	//새소식 수정
+	@PatchMapping("/{newsfeedId}")
+	public ResponseEntity<ApiResponseDto<NewsfeedResponse>> updateNewsfeed(
+		@PathVariable Long newsfeedId,
+		@RequestBody NewsfeedRequest request,
+		@AuthenticationPrincipal CustomPrincipal principal
+	) {
+		NewsfeedResponse updateNewsfeed = newsfeedService.updateNewsfeed(newsfeedId, request, principal.getId());
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 수정이 완료되었습니다.", updateNewsfeed));
+	}
+
+	//새소식 삭제
+	@DeleteMapping("/{newsfeedId}")
+	public ResponseEntity<ApiResponseDto<Void>> softDeleteNewsfeed(
+		@PathVariable Long newsfeedId,
+		@AuthenticationPrincipal CustomPrincipal principal
+	) {
+		newsfeedService.softDeleteNewsfeed(newsfeedId, principal.getId());
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponseDto.of("게시글 삭제가 완료되었습니다.", null));
+	}
 }

--- a/src/main/java/com/example/place/domain/newsfeed/entity/Newsfeed.java
+++ b/src/main/java/com/example/place/domain/newsfeed/entity/Newsfeed.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import com.example.place.common.entity.SoftDeleteEntity;
 import com.example.place.domain.Image.entity.Image;
+import com.example.place.domain.newsfeed.dto.request.NewsfeedRequest;
 import com.example.place.domain.user.entity.User;
 
 import jakarta.persistence.*;
@@ -40,6 +41,11 @@ public class Newsfeed extends SoftDeleteEntity {
 		this.user = user;
 		this.title = title;
 		this.content = content;
+	}
+
+	public void updateNewsfeed(NewsfeedRequest request) {
+		this.title = request.getTitle();
+		this.content = request.getContent();
 	}
 
 	public static Newsfeed of(User user, String title, String content) {

--- a/src/main/java/com/example/place/domain/newsfeed/repository/NewsfeedRepository.java
+++ b/src/main/java/com/example/place/domain/newsfeed/repository/NewsfeedRepository.java
@@ -1,16 +1,24 @@
 package com.example.place.domain.newsfeed.repository;
 
+import java.util.Optional;
+
 import com.example.place.domain.newsfeed.entity.Newsfeed;
 import com.example.place.domain.user.entity.User;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NewsfeedRepository extends JpaRepository<Newsfeed, Long> {
 
 	Page<Newsfeed> findByIsDeletedFalse(Pageable pageable);
+
+	// NewsfeedRepository에 추가
+	@Query("SELECT n FROM Newsfeed n LEFT JOIN FETCH n.images WHERE n.id = :id")
+	Optional<Newsfeed> findByIdWithImages(@Param("id") Long id);
 
 }

--- a/src/main/java/com/example/place/domain/newsfeed/repository/NewsfeedRepository.java
+++ b/src/main/java/com/example/place/domain/newsfeed/repository/NewsfeedRepository.java
@@ -12,4 +12,5 @@ import org.springframework.stereotype.Repository;
 public interface NewsfeedRepository extends JpaRepository<Newsfeed, Long> {
 
 	Page<Newsfeed> findByIsDeletedFalse(Pageable pageable);
+
 }


### PR DESCRIPTION
## 개요
생성된 새소식을 수정, 삭제할 수 있습니다.

## 작업 사항
- /api/newsfeeds/{newsfeedId} 구현
- /api/newsfeeds/{newsfeedId} 구현
- 이미지 수정 로직에서 아이템과 뉴스피드가 따로 처리되도록 분리

## 리뷰 요청 포인트
- 예: 로직 흐름 자연스러운지 확인 부탁드립니다.
- 예: 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #123
- 참고 자료: [링크]

---
