### PR TITLE
feat: 단건조회 이미지 로직 분리

### DIFF
--- a/src/main/java/com/example/place/domain/Image/dto/ImageDto.java
+++ b/src/main/java/com/example/place/domain/Image/dto/ImageDto.java
@@ -1,0 +1,22 @@
+package com.example.place.domain.Image.dto;
+
+import java.util.List;
+
+import com.example.place.domain.Image.entity.Image;
+
+import lombok.Getter;
+
+@Getter
+public class ImageDto {
+	private List<String> imageUrls;
+	private int mainIndex;
+
+	private ImageDto(List<String> imageUrls, int mainIndex) {
+		this.imageUrls = imageUrls;
+		this.mainIndex = mainIndex;
+	}
+
+	public static ImageDto of(List<String> imageUrls, int mainIndex) {
+		return new ImageDto(imageUrls, mainIndex);
+	}
+}

--- a/src/main/java/com/example/place/domain/item/dto/response/ItemResponse.java
+++ b/src/main/java/com/example/place/domain/item/dto/response/ItemResponse.java
@@ -1,5 +1,6 @@
 package com.example.place.domain.item.dto.response;
 
+import com.example.place.domain.Image.dto.ImageDto;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.item.entity.Item;
 import lombok.Getter;
@@ -24,17 +25,7 @@ public class ItemResponse {
     private int mainIndex;
     private List<String> tags;
 
-    public static ItemResponse from(Item item) {
-        List<Image> images = item.getImages();
-        List<String> imageUrls = new ArrayList<>();
-        int mainIndex = 0;
-        for (int i = 0; i < images.size(); i++) {
-            imageUrls.add(images.get(i).getImageUrl());
-            if (images.get(i).isMain()) {
-                mainIndex = i;
-            }
-        }
-
+    public static ItemResponse from(Item item, ImageDto imageDto) {
         List<String> tagNames = item.getItemTags().stream()
                 .map(itemTag -> itemTag.getTag().getTagName())
                 .toList();
@@ -49,8 +40,8 @@ public class ItemResponse {
 
         response.salesStartAt = item.getSalesStartAt();
         response.salesEndAt = item.getSalesEndAt();
-        response.imageUrls = imageUrls;
-        response.mainIndex = mainIndex;
+        response.imageUrls = imageDto.getImageUrls();
+        response.mainIndex = imageDto.getMainIndex();
         response.tags = tagNames;
         return response;
     }

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -80,6 +80,7 @@ public class ItemService {
 	@Transactional(readOnly = true)
 	public ItemResponse getItem(Long itemId) {
 		Item item = findByIdOrElseThrow(itemId);
+
 		ImageDto imageDto = imageService.getImages(itemId);
 		return ItemResponse.from(item, imageDto);
 	}

--- a/src/main/java/com/example/place/domain/item/service/ItemService.java
+++ b/src/main/java/com/example/place/domain/item/service/ItemService.java
@@ -13,8 +13,6 @@ import com.example.place.domain.item.dto.response.ItemGetAllResponse;
 import com.example.place.domain.item.entity.Item;
 import com.example.place.domain.item.repository.ItemRepository;
 
-import com.example.place.domain.post.dto.response.PostGetAllResponseDto;
-import com.example.place.domain.post.entity.Post;
 import com.example.place.domain.tag.service.TagService;
 import com.example.place.domain.user.entity.User;
 import com.example.place.domain.user.entity.UserRole;
@@ -26,7 +24,6 @@ import org.springframework.stereotype.Service;
 
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
-import com.example.place.domain.vote.dto.response.VoteResponseDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -81,7 +78,7 @@ public class ItemService {
 	public ItemResponse getItem(Long itemId) {
 		Item item = findByIdOrElseThrow(itemId);
 
-		ImageDto imageDto = imageService.getImages(itemId);
+		ImageDto imageDto = imageService.getItemImages(itemId);
 		return ItemResponse.from(item, imageDto);
 	}
 
@@ -147,7 +144,7 @@ public class ItemService {
 		}
 		ImageDto imageDto = (request.getImageUrls() != null)
 			? imageService.updateImages(item, request.getImageUrls(), request.getMainIndex())
-			: imageService.getImages(itemId);
+			: imageService.getItemImages(itemId);
 
 		// 연관 태그 수정
 		if(request.getItemTagNames() != null) {

--- a/src/main/java/com/example/place/domain/newsfeed/dto/response/NewsfeedResponse.java
+++ b/src/main/java/com/example/place/domain/newsfeed/dto/response/NewsfeedResponse.java
@@ -3,6 +3,7 @@ package com.example.place.domain.newsfeed.dto.response;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.example.place.domain.Image.dto.ImageDto;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.newsfeed.entity.Newsfeed;
 
@@ -19,23 +20,14 @@ public class NewsfeedResponse {
 	private List<String> imageUrls;
 	private int mainIndex;
 
-	public static com.example.place.domain.newsfeed.dto.response.NewsfeedResponse from(Newsfeed newsfeed) {
-		List<Image> images = newsfeed.getImages();
-		List<String> imageUrls = new ArrayList<>();
-		int mainIndex = 0;
-		for (int i = 0; i < images.size(); i++) {
-			imageUrls.add(images.get(i).getImageUrl());
-			if (images.get(i).isMain()) {
-				mainIndex = i;
-			}
-		}
-
+	public static com.example.place.domain.newsfeed.dto.response.NewsfeedResponse from(Newsfeed newsfeed,
+		ImageDto imageDto) {
 		com.example.place.domain.newsfeed.dto.response.NewsfeedResponse response = new com.example.place.domain.newsfeed.dto.response.NewsfeedResponse();
 		response.id = newsfeed.getId();
 		response.title = newsfeed.getTitle();
 		response.content = newsfeed.getContent();
-		response.imageUrls = imageUrls;
-		response.mainIndex = mainIndex;
+		response.imageUrls = imageDto.getImageUrls();
+		response.mainIndex = imageDto.getMainIndex();
 		return response;
 	}
 }

--- a/src/main/java/com/example/place/domain/newsfeed/service/NewsfeedService.java
+++ b/src/main/java/com/example/place/domain/newsfeed/service/NewsfeedService.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import com.example.place.common.annotation.Loggable;
 import com.example.place.common.dto.PageResponseDto;
+import com.example.place.domain.Image.dto.ImageDto;
 import com.example.place.domain.Image.repository.ImageRepository;
 import com.example.place.domain.Image.service.ImageService;
 import com.example.place.domain.Image.entity.Image;
@@ -50,16 +51,18 @@ public class NewsfeedService {
 		);
 		Newsfeed savedNewsfeed = newsfeedRepository.save(newsfeed);
 		// 이미지 저장
-		imageService.createImages(savedNewsfeed, request.getImageUrls(), request.getMainIndex());
+		ImageDto imageDto = imageService.createImages(savedNewsfeed, request.getImageUrls(), request.getMainIndex());
 
-		return NewsfeedResponse.from(savedNewsfeed);
+		return NewsfeedResponse.from(savedNewsfeed, imageDto);
 	}
 
 	@Loggable
 	@Transactional(readOnly = true)
 	public NewsfeedResponse getNewsfeed(Long newsfeedId) {
 		Newsfeed newsfeed = findByIdOrElseThrow(newsfeedId);
-		return NewsfeedResponse.from(newsfeed);
+
+		ImageDto imageDto = imageService.getNewsfeedImages(newsfeedId);
+		return NewsfeedResponse.from(newsfeed, imageDto);
 	}
 
 	@Loggable
@@ -129,11 +132,11 @@ public class NewsfeedService {
 			|| (request.getImageUrls() != null && request.getMainIndex() == null)) {
 			throw new CustomException(ExceptionCode.INVALID_IMAGE_UPDATE_REQUEST);
 		}
-		if (request.getImageUrls() != null) {
-			imageService.updateImages(newsfeed, request.getImageUrls(), request.getMainIndex());
-		}
+		ImageDto imageDto = (request.getImageUrls() != null)
+			? imageService.updateImages(newsfeed, request.getImageUrls(), request.getMainIndex())
+			: imageService.getNewsfeedImages(newsfeedId);
 
-		return NewsfeedResponse.from(newsfeed);
+		return NewsfeedResponse.from(newsfeed, imageDto);
 	}
 
 	@Loggable

--- a/src/main/java/com/example/place/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/place/domain/post/dto/response/PostResponseDto.java
@@ -3,6 +3,7 @@ package com.example.place.domain.post.dto.response;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.example.place.domain.Image.dto.ImageDto;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.post.entity.Post;
 
@@ -25,22 +26,12 @@ public class PostResponseDto {
 		this.mainIndex = mainIndex;
 	}
 
-	public static PostResponseDto from(Post post) {
-		List<Image> images = post.getItem().getImages();
-		List<String> imageUrls = new ArrayList<>();
-		int mainIndex = 0;
-		for (int i = 0; i < images.size(); i++) {
-			imageUrls.add(images.get(i).getImageUrl());
-			if (images.get(i).isMain()) {
-				mainIndex = i;
-			}
-		}
-
+	public static PostResponseDto from(Post post, ImageDto imageDto) {
 		return new PostResponseDto(
 			post.getContent(),
 			post.getUser().getNickname(),
 			post.getItem().getId(),
-			imageUrls,
-			mainIndex);
+			imageDto.getImageUrls(),
+			imageDto.getMainIndex());
 	}
 }

--- a/src/main/java/com/example/place/domain/post/service/PostService.java
+++ b/src/main/java/com/example/place/domain/post/service/PostService.java
@@ -1,19 +1,14 @@
 package com.example.place.domain.post.service;
 
 import java.util.List;
-import java.util.Map;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.example.place.common.annotation.Loggable;
-import com.example.place.common.dto.PageResponseDto;
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
 import com.example.place.domain.Image.dto.ImageDto;
-import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.Image.service.ImageService;
 import com.example.place.domain.post.dto.response.PostResponseDto;
 import com.example.place.domain.user.entity.User;
@@ -46,7 +41,7 @@ public class PostService {
 		Post post = Post.of(user, item, request.getContent());
 		Post saved = postRepository.save(post);
 
-		ImageDto imageDto = imageService.getImages(saved.getItem().getId());
+		ImageDto imageDto = imageService.getItemImages(saved.getItem().getId());
 		return PostResponseDto.from(saved, imageDto);
 	}
 
@@ -56,7 +51,7 @@ public class PostService {
 	public PostResponseDto getPost(Long postId) {
 		Post post = findByIdOrElseThrow(postId);
 
-		ImageDto imageDto = imageService.getImages(post.getItem().getId());
+		ImageDto imageDto = imageService.getItemImages(post.getItem().getId());
 		return PostResponseDto.from(post, imageDto);
 	}
 
@@ -71,7 +66,7 @@ public class PostService {
 		}
 
 		post.update(request.getContent());
-		ImageDto imageDto = imageService.getImages(post.getItem().getId());
+		ImageDto imageDto = imageService.getItemImages(post.getItem().getId());
 		return PostResponseDto.from(post, imageDto);
 	}
 

--- a/src/main/java/com/example/place/domain/post/service/PostService.java
+++ b/src/main/java/com/example/place/domain/post/service/PostService.java
@@ -12,6 +12,7 @@ import com.example.place.common.annotation.Loggable;
 import com.example.place.common.dto.PageResponseDto;
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
+import com.example.place.domain.Image.dto.ImageDto;
 import com.example.place.domain.Image.entity.Image;
 import com.example.place.domain.Image.service.ImageService;
 import com.example.place.domain.post.dto.response.PostResponseDto;
@@ -45,7 +46,8 @@ public class PostService {
 		Post post = Post.of(user, item, request.getContent());
 		Post saved = postRepository.save(post);
 
-		return PostResponseDto.from(saved);
+		ImageDto imageDto = imageService.getImages(saved.getItem().getId());
+		return PostResponseDto.from(saved, imageDto);
 	}
 
 	//살까말까 단건 조회
@@ -53,7 +55,9 @@ public class PostService {
 	@Transactional(readOnly = true)
 	public PostResponseDto getPost(Long postId) {
 		Post post = findByIdOrElseThrow(postId);
-		return PostResponseDto.from(post);
+
+		ImageDto imageDto = imageService.getImages(post.getItem().getId());
+		return PostResponseDto.from(post, imageDto);
 	}
 
 	//살까말까 수정
@@ -67,7 +71,8 @@ public class PostService {
 		}
 
 		post.update(request.getContent());
-		return PostResponseDto.from(post);
+		ImageDto imageDto = imageService.getImages(post.getItem().getId());
+		return PostResponseDto.from(post, imageDto);
 	}
 
 	//살까말까 삭제


### PR DESCRIPTION
## 개요
이미지 책임분리를 위하여 단건조회 시에도 이미지 서비스를 통하여 이미지 정보를 반환 받도록 분리하였습니다.

## 작업 사항
- 상품 단건 조회 이미지 로직 분리
- 게시글 단건 조회 이미지 로직 분리
- 새소식 단건 조회 이미지 로직 분리

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
- 관련 이슈: #291 
- 참고 자료: [링크]

---
