### PR TITLE
재고 관리 동시성 문제 해결(트랜잭션 옵션 수정)

### DIFF
--- a/src/main/java/com/example/place/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/example/place/domain/item/repository/ItemRepository.java
@@ -2,11 +2,18 @@ package com.example.place.domain.item.repository;
 
 import com.example.place.domain.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositoryCustom {
-
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT i FROM Item i WHERE i.id = :itemId")
+	Optional<Item> findByIdWithLock(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/example/place/domain/item/service/StockService.java
+++ b/src/main/java/com/example/place/domain/item/service/StockService.java
@@ -6,10 +6,13 @@ import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.place.common.exception.enums.ExceptionCode;
 import com.example.place.common.exception.exceptionclass.CustomException;
 import com.example.place.domain.item.entity.Item;
+import com.example.place.domain.item.repository.ItemRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,10 +20,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StockService {
 	@Lazy
-	private final ItemService itemService;
 	private final RedissonClient redissonClient;
+	private final ItemRepository itemRepository;
 
 	// 분산락 재고감소
+	// @Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void decreaseStock(Long itemId, Long quantity) {
 		String lockKey = "Lock:" + itemId;
 		RLock lock = redissonClient.getLock(lockKey);
@@ -34,24 +39,27 @@ public class StockService {
 				throw new CustomException(ExceptionCode.STOCK_LOCK_FAILED);
 			}
 
-			Item item = itemService.findByIdOrElseThrow(itemId);
+			try {
+				Item item = itemRepository.findByIdWithLock(itemId)
+					.orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_ITEM));
 
-			if (item.getCount() < quantity) {
-				throw new CustomException(ExceptionCode.OUT_OF_STOCK);
+				// 실제 제고감소
+				item.decreaseStock(quantity);
+
+			}finally {
+				if (lock.isHeldByCurrentThread()) {
+					lock.unlock();
+				}
 			}
-			// 실제 제고감소
-			item.decreaseStock(quantity);
+
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			throw new CustomException(ExceptionCode.OPERATION_INTERRUPTED);
-		} finally {
-			if (lock.isHeldByCurrentThread()) {
-				lock.unlock();
-			}
 		}
 	}
 
 	// 분산락 재고증가
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void increaseStock(Long itemId, Long quantity) {
 		String lockKey = "Lock:" + itemId;
 		RLock lock = redissonClient.getLock(lockKey);
@@ -61,17 +69,21 @@ public class StockService {
 				throw new CustomException(ExceptionCode.STOCK_LOCK_FAILED);
 			}
 
-			Item item = itemService.findByIdOrElseThrow(itemId);
-			// 재고 증가
-			item.increaseStock(quantity);
+			try {
+				Item item = itemRepository.findByIdWithLock(itemId)
+					.orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_ITEM));
+
+				item.increaseStock(quantity);
+
+			} finally {
+				if (lock.isHeldByCurrentThread()) {
+					lock.unlock();
+				}
+			}
 
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			throw new CustomException(ExceptionCode.OPERATION_INTERRUPTED);
-		} finally {
-			if (lock.isHeldByCurrentThread()) {
-				lock.unlock();
-			}
 		}
 	}
 }

--- a/src/main/java/com/example/place/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/place/domain/order/service/OrderService.java
@@ -42,7 +42,6 @@ public class OrderService {
 	public CreateOrderResponseDto createOrder(CreateOrderRequestDto requestDto,Long userId
 	) {
 		User user = userService.findByIdOrElseThrow(userId);
-
 		Item item = itemService.findByIdOrElseThrow(requestDto.getItemId());
 
 		// 상품 소프트딜리트 확인
@@ -50,13 +49,11 @@ public class OrderService {
 			throw new CustomException(ExceptionCode.NOT_FOUND_ITEM);
 		}
 
-		// 수량 유무 확인
-		if (item.getCount() < requestDto.getQuantity()) {
-			throw new CustomException(ExceptionCode.OUT_OF_STOCK);
-		}
-
 		// 판매 기간 유무 검증
 		item.validateSalesPeriod();
+
+		// 주문으로 인한 재고 차감
+		stockService.decreaseStock(item.getId(),requestDto.getQuantity());
 
 		Order order = new Order(user,
 			item,
@@ -68,9 +65,6 @@ public class OrderService {
 		);
 
 		orderRepository.save(order);
-
-		// 주문으로 인한 재고 차감
-		stockService.decreaseStock(item.getId(),requestDto.getQuantity());
 
 		// 메인 이미지 추가
 		String mainImageUrl = imageService.getMainImageUrl(item.getId());
@@ -191,5 +185,4 @@ public class OrderService {
 			order.clearItem();
 		}
 	}
-
 }


### PR DESCRIPTION
## 개요

문제상황:
- 동시 주문 시 재고 수량을 초과하여 판매되는 문제 발생
- Redis 분산락은 정상 동작하지만 트랜잭션 커밋 타이밍 문제로 인해
  락 해제 후에도 DB에 변경사항이 반영되지 않음

해결방법:
- REQUIRES_NEW 전파 옵션 적용
- DB Lock 추가
- 
## 작업 사항
- [O] 기능 A 구현
- [ ] 기능 B 리팩토링
- [ ] 테스트 코드 작성
